### PR TITLE
Make the end-to-end suite opt-in and a separate CI step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,6 @@ jobs:
 
     - name: Run pre-commit checks
       run: just pre-commit
+
+    - name: Run end-to-end tests
+      run: just test-e2e

--- a/Justfile
+++ b/Justfile
@@ -11,7 +11,7 @@ build-release:
     go build -ldflags="-s -w" -o http-assert .
 
 [doc("Run all pre-commit checks")]
-pre-commit: build vet lint test test-race test-cover security
+pre-commit: build vet lint test test-race security
 
 [doc("Build and check compilation without creating binary")]
 check:
@@ -25,9 +25,13 @@ vet:
 lint:
     golangci-lint run ./...
 
-[doc("Run tests")]
+[doc("Run unit tests (fast; end-to-end tests are skipped)")]
 test:
     go test ./...
+
+[doc("Run the end-to-end suite (builds and executes the CLI)")]
+test-e2e:
+    go test ./... -e2e -count=1
 
 [doc("Run tests with race detection")]
 test-race:
@@ -43,7 +47,7 @@ test-cover:
     set -euo pipefail
     unit=$(mktemp -d); e2e=$(mktemp -d)
     trap 'rm -rf "$unit" "$e2e"' EXIT
-    E2E_COVERDIR="$e2e" go test ./... -cover -args -test.gocoverdir="$unit"
+    E2E_COVERDIR="$e2e" go test ./... -e2e -count=1 -cover -args -test.gocoverdir="$unit"
     go tool covdata percent -i="$unit,$e2e"
 
 [doc("Run tests with coverage and generate HTML report")]
@@ -52,7 +56,7 @@ test-coverage:
     set -euo pipefail
     unit=$(mktemp -d); e2e=$(mktemp -d)
     trap 'rm -rf "$unit" "$e2e"' EXIT
-    E2E_COVERDIR="$e2e" go test ./... -cover -args -test.gocoverdir="$unit"
+    E2E_COVERDIR="$e2e" go test ./... -e2e -count=1 -cover -args -test.gocoverdir="$unit"
     go tool covdata textfmt -i="$unit,$e2e" -o=coverage.out
     go tool cover -html=coverage.out -o coverage.html
     echo "Coverage report: coverage.html"
@@ -63,7 +67,7 @@ test-cover-func:
     set -euo pipefail
     unit=$(mktemp -d); e2e=$(mktemp -d)
     trap 'rm -rf "$unit" "$e2e"' EXIT
-    E2E_COVERDIR="$e2e" go test ./... -cover -args -test.gocoverdir="$unit" >/dev/null
+    E2E_COVERDIR="$e2e" go test ./... -e2e -count=1 -cover -args -test.gocoverdir="$unit" >/dev/null
     go tool covdata func -i="$unit,$e2e" | sort -k2 -n
 
 [doc("Clean build artifacts")]
@@ -86,6 +90,9 @@ deps-update:
 [doc("Download dependencies")]
 deps-download:
     go mod download
+
+[doc("Run every check CI runs, including the end-to-end suite")]
+pre-push: pre-commit test-e2e
 
 [doc("Run a quick development cycle")]
 dev: fmt vet test

--- a/e2e_harness_test.go
+++ b/e2e_harness_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -18,6 +19,15 @@ import (
 // #55 run() extraction, #56 assertion constructors), which is the property that
 // makes those refactors safe to perform.
 
+// runE2E gates the whole suite. It is opt-in: `go test ./...` runs the unit
+// tests only, and the end-to-end tests run when explicitly asked for.
+//
+// A registered flag is used rather than a build tag on purpose. A tagged file
+// is invisible to `go vet` and `golangci-lint` unless every invocation passes
+// the tag, so tagging would silently drop this file out of both -- verified,
+// and the reason the switch lives here instead.
+var runE2E = flag.Bool("e2e", false, "run the end-to-end suite (builds and executes the CLI)")
+
 var (
 	binPath  string
 	buildErr error
@@ -34,6 +44,10 @@ func coverDir() string { return os.Getenv("E2E_COVERDIR") }
 // toward the reported coverage.
 func binary(t *testing.T) string {
 	t.Helper()
+
+	if !*runE2E {
+		t.Skip("e2e: pass -e2e to run (or use `just test-e2e`)")
+	}
 
 	buildOne.Do(func() {
 		dir, err := os.MkdirTemp("", "http-assert-e2e")


### PR DESCRIPTION
## Problem

The end-to-end suite ran three times per CI job — about 32s of the runtime — and slowed `go test ./...` from 0.5s to 11s for everyone.

`pre-commit` chains `test`, `test-race` and `test-cover`, and each pulled in the full suite. Two of those runs bought almost nothing:

- **`test` and `test-cover` are near-duplicates.** `test-cover` runs the identical tests and additionally reports coverage.
- **`test-race` was checking the wrong process.** `-race` instruments the *test* binary, but the harness builds the CLI with a separate plain `go build`, so the race detector covered the harness and the `httptest` servers — not one line of `http-assert`. (A race build is 12.1 MB vs 9.9 MB plain; the child is the plain one.)

The redundancy predates the suite — `pre-commit` always ran three test passes. Adding e2e just turned a latent waste into a visible one.

## Solution

Gate the suite behind an opt-in `-e2e` flag and give it a CI step of its own, so it runs exactly once.

```
just test        0.5s   unit only
just test-e2e   10.4s   the suite, explicitly
just pre-push          both, for the CI contract locally
```

```yaml
- name: Run pre-commit checks     # build, vet, lint, unit tests, race, gosec
  run: just pre-commit

- name: Run end-to-end tests      # its own step, its own line in the CI UI
  run: just test-e2e
```

**CI e2e time: ~32s → ~10s**, and a failure now names itself instead of hiding inside a composite recipe.

### Why a flag and not a build tag

A `//go:build e2e` file is invisible to `go vet` and `golangci-lint` unless *every* invocation passes the tag. Tested on a file carrying both a `Printf` argument mismatch and dead code:

| Command | Result |
|---|---|
| `go vet ./...` | clean |
| `golangci-lint run ./...` | `0 issues.` |
| `go vet -tags=e2e ./...` | catches the `Printf` bug |
| `golangci-lint run --build-tags=e2e ./...` | `2 issues: govet 1, unused 1` |

Tagging would drop 1,100 lines of test code out of both linters, silently, because the recipes are plain `go vet ./...` and `golangci-lint run ./...`. A registered flag gives the same opt-in default with every file still compiled and analysed.

### Why the check lives in `binary()`

Putting it in the one function every e2e test already routes through means a test added later inherits the gate automatically. There is no per-file marker to forget, and no way to write an e2e test that quietly runs in the fast loop.

Coverage is unaffected: `test-cover` opts into `-e2e` itself and still reports **99.3%**.

## Other Changes

Adds `just pre-push` (`pre-commit` + `test-e2e`) — the full CI contract in one local command.

One consequence worth naming: `just pre-commit` no longer exercises the suite, so a break there surfaces in CI rather than before the commit. That is the intended trade — a fast inner loop, with `pre-push` available for anyone who wants to find out earlier.

Related:
- https://github.com/korya/http-assert/pull/57

🤖 Generated with [Claude Code](https://claude.com/claude-code)
