### PR TITLE
Reject unparseable regexp patterns instead of panicking

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+version: "2"
+
+# Only additions to the standard linter set; the defaults (errcheck, govet,
+# ineffassign, staticcheck, unused) stay enabled.
+linters:
+  enable:
+    - forbidigo
+  settings:
+    forbidigo:
+      forbid:
+        # regexp.MustCompile panics on a bad pattern. Every pattern in this
+        # program comes from a flag value, so a panic is a crash on user input
+        # rather than a programmer error (#17). Compile and report instead.
+        - pattern: '^regexp\.MustCompile$'
+          msg: "use regexp.Compile and report the error; MustCompile panics on user input (#17)"

--- a/Justfile
+++ b/Justfile
@@ -11,7 +11,7 @@ build-release:
     go build -ldflags="-s -w" -o http-assert .
 
 [doc("Run all pre-commit checks")]
-pre-commit: build tidy-check vet lint test test-race security
+pre-commit: build tidy-check lint-config-check vet lint test test-race security
 
 [doc("Build and check compilation without creating binary")]
 check:
@@ -20,6 +20,28 @@ check:
 [doc("Fail if go.mod or go.sum is not tidy")]
 tidy-check:
     go mod tidy -diff
+
+[doc("Fail if the standard linters are no longer enabled")]
+lint-config-check:
+    #!/usr/bin/env bash
+    # .golangci.yml is meant to ADD to the default linter set, never replace it.
+    # Setting `linters.default: none` would silently drop the standard linters,
+    # and nothing would fail -- fewer linters simply means fewer findings. This
+    # asserts the set we expect to be active really is.
+    set -euo pipefail
+    enabled=$(golangci-lint linters | sed -n '/^Enabled/,/^Disabled/p' | grep -oE '^[a-z0-9]+' || true)
+    # Distinguish "could not parse" from "the set really did shrink" -- both
+    # must fail, but conflating them sends the next reader to the wrong file.
+    if [ -z "$enabled" ]; then
+      echo "cannot read the enabled linters from 'golangci-lint linters'; the parser is stale" >&2
+      exit 1
+    fi
+    for l in errcheck govet ineffassign staticcheck unused forbidigo; do
+      if ! echo "$enabled" | grep -qx "$l"; then
+        echo "linter '$l' is no longer enabled -- check linters.default in .golangci.yml" >&2
+        exit 1
+      fi
+    done
 
 [doc("Run go vet")]
 vet:

--- a/assertions.go
+++ b/assertions.go
@@ -7,6 +7,10 @@ import (
 
 type Assertion func(res *httpResponse) error
 
+// Pattern-based assertions are built from user input and so can fail before any
+// response exists. They return an error rather than panicking; every other
+// constructor in this file is infallible and returns an Assertion directly.
+
 func AssertStatusOK() Assertion {
 	return func(res *httpResponse) error {
 		if s := res.StatusCode; s < 200 || s >= 400 {
@@ -77,8 +81,11 @@ func AssertHeaderEqual(name, expValue string) Assertion {
 	}
 }
 
-func AssertHeaderMatch(name, expPattern string) Assertion {
-	re := regexp.MustCompile(expPattern)
+func AssertHeaderMatch(name, expPattern string) (Assertion, error) {
+	re, err := regexp.Compile(expPattern)
+	if err != nil {
+		return nil, err
+	}
 
 	return func(res *httpResponse) error {
 		vs := res.Header.Values(name)
@@ -94,7 +101,7 @@ func AssertHeaderMatch(name, expPattern string) Assertion {
 		}
 
 		return fmt.Errorf("header[%s]: expected to match %q, got %q", name, expPattern, vs)
-	}
+	}, nil
 }
 
 func AssertBodyEmpty() Assertion {
@@ -121,8 +128,11 @@ func AssertBodyEqual(expContent string) Assertion {
 	}
 }
 
-func AssertBodyMatch(expPattern string) Assertion {
-	re := regexp.MustCompile(expPattern)
+func AssertBodyMatch(expPattern string) (Assertion, error) {
+	re, err := regexp.Compile(expPattern)
+	if err != nil {
+		return nil, err
+	}
 
 	return func(res *httpResponse) error {
 		if len(res.BodyBytes) == 0 {
@@ -134,7 +144,7 @@ func AssertBodyMatch(expPattern string) Assertion {
 		}
 
 		return nil
-	}
+	}, nil
 }
 
 func AssertRedirectEqual(expLocation string) Assertion {
@@ -157,8 +167,11 @@ func AssertRedirectEqual(expLocation string) Assertion {
 	}
 }
 
-func AssertRedirectMatch(expPattern string) Assertion {
-	re := regexp.MustCompile(expPattern)
+func AssertRedirectMatch(expPattern string) (Assertion, error) {
+	re, err := regexp.Compile(expPattern)
+	if err != nil {
+		return nil, err
+	}
 
 	return func(res *httpResponse) error {
 		if s := res.StatusCode; s < 300 || s >= 400 {
@@ -176,5 +189,5 @@ func AssertRedirectMatch(expPattern string) Assertion {
 		}
 
 		return nil
-	}
+	}, nil
 }

--- a/assertions_test.go
+++ b/assertions_test.go
@@ -198,7 +198,10 @@ func Test_AssertHeader(t *testing.T) {
 	present := AssertHeaderPresent("taRgEt")
 	missing := AssertHeaderMissing("taRgEt")
 	equal := AssertHeaderEqual("taRgET", "value")
-	match := AssertHeaderMatch("taRget", `(?i)^val.*$`)
+	match, err := AssertHeaderMatch("taRget", `(?i)^val.*$`)
+	if err != nil {
+		t.Fatalf("unexpected error building the assertion: %s", err)
+	}
 	for _, tc := range testCases {
 		t.Run(tc.CaseName, func(t *testing.T) {
 			res := &httpResponse{
@@ -266,7 +269,10 @@ func Test_AssertBody(t *testing.T) {
 
 	empty := AssertBodyEmpty()
 	equal := AssertBodyEqual("value")
-	match := AssertBodyMatch(`(?i)^val.*$`)
+	match, err := AssertBodyMatch(`(?i)^val.*$`)
+	if err != nil {
+		t.Fatalf("unexpected error building the assertion: %s", err)
+	}
 	for _, tc := range testCases {
 		t.Run(tc.CaseName, func(t *testing.T) {
 			res := &httpResponse{BodyBytes: tc.Body}
@@ -430,7 +436,10 @@ func Test_AssertRedirect(t *testing.T) {
 	}
 
 	equal := AssertRedirectEqual(`https://example.com/`)
-	match := AssertRedirectMatch(`(?i)example\.[a-z]*/$`)
+	match, err := AssertRedirectMatch(`(?i)example\.[a-z]*/$`)
+	if err != nil {
+		t.Fatalf("unexpected error building the assertion: %s", err)
+	}
 	for _, tc := range testCases {
 		t.Run(tc.CaseName, func(t *testing.T) {
 			res := &httpResponse{
@@ -443,6 +452,46 @@ func Test_AssertRedirect(t *testing.T) {
 
 			checkErr(t, "equal", equal(res), tc.ExpEqualError)
 			checkErr(t, "match", match(res), tc.ExpMatchError)
+		})
+	}
+}
+
+// Test_AssertMatchConstructorsRejectBadPatterns covers the failure path the
+// pattern-based constructors gained when they stopped panicking (#17).
+func Test_AssertMatchConstructorsRejectBadPatterns(t *testing.T) {
+	t.Parallel()
+
+	constructors := map[string]func(string) (Assertion, error){
+		"AssertBodyMatch":     AssertBodyMatch,
+		"AssertRedirectMatch": AssertRedirectMatch,
+		"AssertHeaderMatch":   func(p string) (Assertion, error) { return AssertHeaderMatch("X-Any", p) },
+	}
+
+	for name, build := range constructors {
+		t.Run(name, func(t *testing.T) {
+			t.Run("unparseable pattern", func(t *testing.T) {
+				a, err := build("[unclosed")
+				if err == nil {
+					t.Fatal("expected an error for an unparseable pattern, got nil")
+				}
+				if a != nil {
+					t.Error("expected a nil Assertion alongside the error")
+				}
+				// The parser's own reason is passed through, not swallowed.
+				if !strings.Contains(err.Error(), "missing closing ]") {
+					t.Errorf("error = %q, want it to explain the syntax problem", err)
+				}
+			})
+
+			t.Run("valid pattern", func(t *testing.T) {
+				a, err := build(`^ok$`)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				if a == nil {
+					t.Fatal("expected an Assertion")
+				}
+			})
 		})
 	}
 }

--- a/e2e_known_issues_test.go
+++ b/e2e_known_issues_test.go
@@ -13,29 +13,37 @@ import (
 // the fix. Select them all with:
 //
 //	go test -run 'TestKnown' ./...
+
+// TestIssue17BadPatternIsRejected pins that an unparseable pattern is reported
+// as an invalid flag value rather than reaching the runtime as a panic.
 //
-// exitPanic is not part of the documented contract -- it is what a Go panic
-// produces, and reaching it is itself the bug (#17).
-const exitPanic = 2
+// This test previously asserted the panic. It flipped when #17 was fixed, which
+// is the record of that change.
+func TestIssue17BadPatternIsRejected(t *testing.T) {
+	for _, tc := range []struct {
+		Flag string
+		Arg  string
+	}{
+		{"--assert-body", "[unclosed"},
+		{"--assert-header", "X-Any: (unclosed"},
+		{"--assert-redirect", "[unclosed"},
+	} {
+		t.Run(tc.Flag, func(t *testing.T) {
+			r := run(t, nil, tc.Flag, tc.Arg, url("/ok"))
 
-// TestKnownIssue17RegexPanic: an invalid regexp crashes with a stack trace
-// instead of reporting an invalid flag value.
-func TestKnownIssue17RegexPanic(t *testing.T) {
-	for _, flag := range []string{"--assert-body", "--assert-header", "--assert-redirect"} {
-		t.Run(flag, func(t *testing.T) {
-			characterizes(t, 17, flag+" panics on an unparseable pattern")
-
-			arg := "[unclosed"
-			if flag == "--assert-header" {
-				arg = "X-Any: (unclosed"
-			}
-			r := run(t, nil, flag, arg, url("/ok"))
-
-			assertExit(t, r, exitPanic)
-			assertContains(t, r, "panic: regexp: Compile")
-			assertContains(t, r, "goroutine 1 [running]:")
+			assertExit(t, r, exitBadFlagVal)
+			// The flag at fault is named, and the parser's reason survives.
+			assertContains(t, r, "Invalid value for "+tc.Flag+" flag")
+			assertContains(t, r, "error parsing regexp")
+			assertNotContains(t, r, "panic:")
+			assertNotContains(t, r, "goroutine")
 		})
 	}
+
+	// A pattern that compiles is unaffected.
+	t.Run("valid patterns still work", func(t *testing.T) {
+		assertExit(t, run(t, nil, "--assert-body", `"status":\s*"success"`, url("/ok")), exitOK)
+	})
 }
 
 // TestKnownIssue18PayloadTruncated: the response dump replaces the body with a

--- a/e2e_panic_test.go
+++ b/e2e_panic_test.go
@@ -56,7 +56,10 @@ func cliFlags(t *testing.T) []flagSpec {
 	}
 
 	// e.g. "  -m, --max-time int   Maximum time ..." or "      --assert-ok   Assert ..."
-	line := regexp.MustCompile(`^\s+(?:-[a-zA-Z], )?--([a-z-]+)(?: ([a-zA-Z]+))?\s{2,}`)
+	line, err := regexp.Compile(`^\s+(?:-[a-zA-Z], )?--([a-z-]+)(?: ([a-zA-Z]+))?\s{2,}`)
+	if err != nil {
+		t.Fatalf("bad flag-line pattern: %s", err)
+	}
 
 	var out []flagSpec
 	for _, l := range strings.Split(flagsSection, "\n") {

--- a/e2e_panic_test.go
+++ b/e2e_panic_test.go
@@ -1,0 +1,145 @@
+package main_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// No malformed flag value may crash the process.
+//
+// The flag list is read from --help at run time rather than hard-coded, so a
+// flag added later is probed automatically. That is the point: a fixed list
+// would silently stop covering the CLI the moment it grew.
+
+// hostileValues are inputs chosen to break parsers rather than to be rejected
+// politely. Being rejected is a fine outcome -- crashing is not.
+var hostileValues = []string{
+	"[unclosed",                // unterminated character class
+	"(unclosed",                // unterminated group
+	"*",                        // quantifier with nothing to repeat
+	"+",                        //
+	"?",                        //
+	`\`,                        // trailing escape
+	`(?P<`,                     // truncated named group
+	"a{2,1}",                   // inverted repetition bounds
+	"%s%d%n",                   // format specifiers
+	"../../../etc/passwd",      // traversal-shaped
+	"-",                        // looks like a flag
+	"--",                       // end-of-flags marker
+	"=",                        //
+	":::=====",                 // confuses the host-mapping split
+	"a:1=b c:2=d",              // whitespace-separated pair
+	"\n\t\r",                   // control whitespace
+	"héllo wörld 日本語",          // multi-byte
+	strings.Repeat("A", 10000), // long
+	strings.Repeat("[", 500),   // deeply unbalanced
+	"",                         // empty
+}
+
+// flagSpec is one flag as advertised by --help.
+type flagSpec struct {
+	Name     string // long name, without dashes
+	TakesArg bool   // whether --help shows a value type after it
+}
+
+// cliFlags parses the Flags section of --help.
+func cliFlags(t *testing.T) []flagSpec {
+	t.Helper()
+
+	r := run(t, nil, "--help")
+	assertExit(t, r, exitOK)
+
+	_, flagsSection, found := strings.Cut(r.Output(), "Flags:")
+	if !found {
+		t.Fatalf("--help has no Flags section; the parser below is stale\n%s", r.Output())
+	}
+
+	// e.g. "  -m, --max-time int   Maximum time ..." or "      --assert-ok   Assert ..."
+	line := regexp.MustCompile(`^\s+(?:-[a-zA-Z], )?--([a-z-]+)(?: ([a-zA-Z]+))?\s{2,}`)
+
+	var out []flagSpec
+	for _, l := range strings.Split(flagsSection, "\n") {
+		m := line.FindStringSubmatch(l)
+		if m == nil || m[1] == "help" {
+			continue
+		}
+		out = append(out, flagSpec{Name: m[1], TakesArg: m[2] != ""})
+	}
+
+	// Guards against a --help format change turning this into a no-op that
+	// probes nothing and passes.
+	if len(out) < 19 {
+		t.Fatalf("parsed only %d flags from --help, expected at least 19 -- parser is stale", len(out))
+	}
+
+	return out
+}
+
+func TestE2ENoFlagPanics(t *testing.T) {
+	flags := cliFlags(t)
+	target := "http://127.0.0.1:1/refused" // nothing listens; the request fails fast
+
+	for _, f := range flags {
+		t.Run(f.Name, func(t *testing.T) {
+			for _, v := range hostileValues {
+				// A bool flag takes its value with '=' or not at all.
+				//
+				// Note that pflag rejects a non-boolean before the value reaches
+				// any of this program's code, so for those flags this probe
+				// mostly exercises the flag layer. Their own parsing paths are
+				// covered by the config matrix and the assertion tests.
+				args := []string{"--" + f.Name + "=" + v, target}
+				if f.TakesArg {
+					args = []string{"--" + f.Name, v, target}
+				}
+
+				r := run(t, nil, args...)
+				assertNoPanic(t, r, "--"+f.Name, v)
+			}
+		})
+	}
+}
+
+// TestE2ENoPanicFromEnvironment covers the other way a value reaches the parsers.
+func TestE2ENoPanicFromEnvironment(t *testing.T) {
+	for _, tc := range envSupportedCases(t) {
+		t.Run(tc.Flag, func(t *testing.T) {
+			for _, v := range hostileValues {
+				r := run(t, map[string]string{tc.EnvKey: v},
+					"--assert-ok", "http://127.0.0.1:1/refused")
+				assertNoPanic(t, r, tc.EnvKey, v)
+			}
+		})
+	}
+}
+
+// TestE2ENoPanicFromPositionalArgument covers the URL, which is not a flag.
+func TestE2ENoPanicFromPositionalArgument(t *testing.T) {
+	for _, v := range hostileValues {
+		r := run(t, nil, "--assert-ok", v)
+		assertNoPanic(t, r, "<URL>", v)
+	}
+}
+
+// assertNoPanic fails only on a crash. Any exit code the CLI chooses
+// deliberately is acceptable -- rejecting bad input is correct behaviour; the
+// contract under test is merely that it is never reported as a Go panic.
+func assertNoPanic(t *testing.T, r result, subject, value string) {
+	t.Helper()
+
+	const goPanicExitCode = 2
+
+	if r.ExitCode == goPanicExitCode || strings.Contains(r.Output(), "panic:") ||
+		strings.Contains(r.Output(), "goroutine ") {
+		t.Fatalf("%s = %q crashed the process (exit %d)\n%s",
+			subject, truncate(value), r.ExitCode, r.Output())
+	}
+}
+
+func truncate(s string) string {
+	if len(s) > 60 {
+		return s[:60] + "..."
+	}
+	return s
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// The parsers below slice strings at offsets derived from strings.Index. Reading
+// them suggests every index is guarded; fuzzing is what turns that reading into
+// evidence. None of them should panic on any input, so each target simply calls
+// the function -- an out-of-range slice or nil dereference fails the test by
+// crashing it.
+//
+// Seed corpora run as ordinary subtests under `go test`, so these guard CI for
+// free. To search for new inputs:
+//
+//	go test -run '^$' -fuzz FuzzParseHostMappings -fuzztime 60s
+
+func FuzzParseHeaderLine(f *testing.F) {
+	for _, s := range []string{
+		"", ":", "a:b", "   a   :   b   ", "Content-Type",
+		"Content-Type:", ":value", "a:b:c", "héllo: wörld", strings.Repeat(":", 100),
+	} {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, l string) {
+		name, value := parseHeaderLine(l)
+		// A name is only empty when the input had nothing before the colon.
+		if name == "" && value != "" && !strings.HasPrefix(strings.TrimSpace(l), ":") {
+			t.Errorf("parseHeaderLine(%q) produced a value %q with no name", l, value)
+		}
+	})
+}
+
+func FuzzParseHostMappings(f *testing.F) {
+	for _, s := range []string{
+		"", "=", "a:1=b", "a:1=b:2", "a=b", "a:zz=b", ":::=====",
+		"a:1=b c:2=d", strings.Repeat("=", 100), strings.Repeat("a:1=b ", 50),
+	} {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, v string) {
+		res, err := parseHostMappings(strings.Fields(v))
+		// The parser abandons its accumulator on failure.
+		if err != nil && res != nil {
+			t.Errorf("parseHostMappings(%q) returned %d mappings alongside an error", v, len(res))
+		}
+		// Every accepted mapping must survive its own accessors.
+		for _, m := range res {
+			_ = m.Matches(v)
+			_ = m.DstHost()
+		}
+	})
+}
+
+func FuzzHostMapping(f *testing.F) {
+	for _, pair := range [][2]string{
+		{"", ""}, {"a:1", "b:2"}, {"*:80", "b"}, {"*", "b"},
+		{":", ":"}, {"a", ""}, {strings.Repeat(":", 50), strings.Repeat(":", 50)},
+	} {
+		f.Add(pair[0], pair[1])
+	}
+
+	f.Fuzz(func(t *testing.T, src, dst string) {
+		m := hostMapping{Src: src, Dst: dst}
+		_ = m.Matches(dst)
+		_ = m.Matches(src)
+
+		// A destination that already carries a port is returned unchanged.
+		if got := m.DstHost(); strings.Contains(dst, ":") && got != dst {
+			t.Errorf("hostMapping{%q, %q}.DstHost() = %q, want the destination unchanged", src, dst, got)
+		}
+	})
+}
+
+func FuzzPrintPayload(f *testing.F) {
+	for _, seed := range []struct {
+		Body []byte
+		Max  int
+	}{
+		{nil, 0}, {[]byte("plain"), 100}, {[]byte("plain"), 2},
+		{[]byte{0x00, 0xff, 0x07}, 100}, {[]byte("héllo"), 3}, {[]byte("x"), -1},
+	} {
+		f.Add(seed.Body, seed.Max)
+	}
+
+	f.Fuzz(func(t *testing.T, body []byte, maxSize int) {
+		cropped := printPayload(io.Discard, body, maxSize)
+		if cropped < 0 {
+			t.Errorf("printPayload(%d bytes, max %d) reported %d cropped", len(body), maxSize, cropped)
+		}
+		if cropped > len(body) {
+			t.Errorf("printPayload reported %d cropped from a %d-byte body", cropped, len(body))
+		}
+	})
+}
+
+func FuzzParseLogLevel(f *testing.F) {
+	for _, s := range []string{"", "debug", "info", "warn", "error", "DEBUG", "  info  "} {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		lvl, ok := parseLogLevel(s)
+		if !ok && lvl != 0 {
+			t.Errorf("parseLogLevel(%q) rejected the value but returned level %d", s, lvl)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -227,6 +227,21 @@ func registerAssertionFlags(cmd *cobra.Command) {
 	cmd.Flags().String("assert-redirect-eq", "", "Assert response redirects to the provided URL")
 }
 
+// mustCompileAssertion builds a pattern-based assertion, reporting an
+// unparseable pattern the way every other invalid flag value is reported.
+//
+// Without this the pattern reached regexp.MustCompile and the process died with
+// a stack trace and exit code 2, which is not part of the documented contract
+// and gave the user no idea which flag was at fault (#17).
+func mustCompileAssertion(flag, pattern string, build func(string) (Assertion, error)) Assertion {
+	a, err := build(pattern)
+	if err != nil {
+		die(71, "Invalid value for %s flag: %s", flag, err)
+	}
+
+	return a
+}
+
 func parseAssertionFlags(cmd *cobra.Command) []Assertion {
 	var res []Assertion
 
@@ -240,7 +255,7 @@ func parseAssertionFlags(cmd *cobra.Command) []Assertion {
 
 	if cmd.Flags().Changed("assert-redirect") {
 		v, _ := cmd.Flags().GetString("assert-redirect")
-		res = append(res, AssertRedirectMatch(v))
+		res = append(res, mustCompileAssertion("--assert-redirect", v, AssertRedirectMatch))
 	}
 	if cmd.Flags().Changed("assert-redirect-eq") {
 		v, _ := cmd.Flags().GetString("assert-redirect-eq")
@@ -269,7 +284,7 @@ func parseAssertionFlags(cmd *cobra.Command) []Assertion {
 
 	if cmd.Flags().Changed("assert-body") {
 		v, _ := cmd.Flags().GetString("assert-body")
-		res = append(res, AssertBodyMatch(v))
+		res = append(res, mustCompileAssertion("--assert-body", v, AssertBodyMatch))
 	}
 	if cmd.Flags().Changed("assert-body-eq") {
 		v, _ := cmd.Flags().GetString("assert-body-eq")
@@ -297,7 +312,8 @@ func parseHeaderAssertions(vs []string, exactMatch bool) []Assertion {
 			if value == "" {
 				res = append(res, AssertHeaderPresent(name))
 			} else {
-				res = append(res, AssertHeaderMatch(name, value))
+				res = append(res, mustCompileAssertion("--assert-header", value,
+					func(p string) (Assertion, error) { return AssertHeaderMatch(name, p) }))
 			}
 		}
 	}

--- a/utils.go
+++ b/utils.go
@@ -22,6 +22,13 @@ func parseHeaderLine(l string) (name, value string) {
 }
 
 func printPayload(w io.Writer, bs []byte, maxSize int) (croppedBytes int) {
+	// A negative limit would slice to a negative bound and panic. The only
+	// caller passes a constant, so this is unreachable today -- but the
+	// function is exported to the rest of the package and should be total.
+	if maxSize < 0 {
+		maxSize = 0
+	}
+
 	if n := len(bs); n > maxSize {
 		bs = bs[:maxSize]
 		croppedBytes = n - maxSize

--- a/utils_test.go
+++ b/utils_test.go
@@ -77,6 +77,13 @@ func Test_printPayload(t *testing.T) {
 			CroppedBytes: 10,
 		},
 		{
+			CaseName:     "negative max size is treated as zero",
+			Input:        []byte("single line"),
+			MaxSize:      -1,
+			Output:       "",
+			CroppedBytes: 11,
+		},
+		{
 			CaseName:     "single line, ASCII, 0",
 			Input:        []byte("single line"),
 			MaxSize:      0,


### PR DESCRIPTION
## Problem

A typo in an assertion pattern crashed the tool with a Go stack trace.

```console
$ http-assert --assert-body '[unclosed' https://api.example.com
panic: regexp: Compile(`[unclosed`): error parsing regexp: missing closing ]: `[unclosed`
goroutine 1 [running]: ...
[exit=2]
```

Three flags carry user-supplied regexps — `--assert-body`, `--assert-header`, `--assert-redirect` — and all three compiled them with `regexp.MustCompile`. Assertion patterns need heavy shell escaping, so typos are routine; in CI this surfaced as a raw crash with an exit code that appears nowhere in the documented contract.

The RCA found these were **the only user input in the program with no validation path.** `--log-level`, `--maphost`, the environment variables, the method and the URL each already report bad values through `die()`. These three had nowhere to report to, because the constructors returned an `Assertion` and nothing else.

Present since the first commit (`0faf21c`, 2021-12-04); `regexp.Compile` had never appeared in this repo. A design gap, not a regression.

## Solution

Give the three constructors error returns, then make the whole class of crash unexpressible.

**Before / after:**

```console
$ http-assert --assert-body '[unclosed' https://api.example.com
Error: Invalid value for --assert-body flag: error parsing regexp: missing closing ]: `[unclosed`
$ echo $?
71
```

Exit 71 matches `--log-level` and `--maphost`, not 103 — that is the *usage* code, and this is a bad value, not bad usage. (A `PreRunE` error would have produced 103; that is why the fix uses `die(71)` directly.)

Fixing one flag proves nothing about the other eighteen, so three guardrails follow, at three different layers:

| Layer | Guardrail | Effect |
|---|---|---|
| Static | `forbidigo` rejects `regexp.MustCompile` | the bug cannot be written |
| Parser | 5 fuzz targets | invariants proven, not read |
| CLI | 540 hostile invocations | no flag can crash the binary |

### The panic probe reads its own flag list

`TestE2ENoFlagPanics` parses `--help` at run time rather than hard-coding 19 flags, so a flag added later is probed without anyone remembering. It asserts it found at least 19, so a `--help` format change fails loudly instead of quietly probing nothing.

Twenty inputs per flag, chosen to break parsers rather than be rejected politely: unterminated classes and groups, trailing escapes, inverted repetition bounds, format specifiers, flag-lookalikes, control whitespace, multi-byte text, a 10,000-character string, 500 unbalanced brackets. Driven through every flag, the six environment variables, and the positional URL.

Only a crash fails it — any exit code the CLI chooses deliberately is correct behaviour.

### Fuzzing found a second panic

Written to *prove* the parsers were safe, the targets failed on their sixth seed:

```
printPayload(w, []byte("x"), -1)  ->  panic: runtime error: slice bounds out of range [:-1]
```

Not reachable today — the sole caller passes the constant `256` — so it is latent, and it survived a static review that correctly identified `MustCompile` as the only *reachable* panic and wrongly concluded it was the only panic. Now guarded; the function is total.

Each target then ran 20s (~5.2M executions, **~26M total**) with no further findings.

### Verified in both directions

Neither guardrail is taken on trust:

- Injecting a panic into `parseHeaderLine` makes the probe report `--assert-header = "[unclosed" crashed the process (exit 2)`.
- Reverting `assertions.go` to `MustCompile` makes `just pre-commit` fail.

An earlier injection into `AssertBodyEmpty` was *not* caught — that is how the recorded limitation was found: pflag rejects a non-boolean before it reaches this program, so for boolean flags the probe mostly exercises the flag layer. Documented in the test rather than papered over.

Coverage stays at **100.0%**. No visual change — headless CLI.

## Other Changes

- **`.golangci.yml` introduced** (the repo had none). It adds only `forbidigo`; the standard set stays enabled, verified by making an unused symbol and the new rule fire together.
- **The default linter set is now asserted, not just documented.** `.golangci.yml` adds to the standard set rather than replacing it — confirmed against the docs (`linters.default` defaults to `standard`; `enable` is additive; `exclusions.presets` defaults to `[]`) and by diffing the enabled linters with and without the config, where the only difference is `+forbidigo`. But `linters.default: none` would silently drop all five standard linters and *look* like success, since fewer linters means fewer findings. A `lint-config-check` recipe now fails if any expected linter is missing. Its two failure modes report differently on purpose: an unreadable output blames the parser, a missing linter names the linter.
- The rule covers test files too. The one legitimate use — a literal pattern in the probe's `--help` parser — was rewritten to compile-and-report rather than carrying a suppression, since an exclusion would apply to every future test.
- `TestKnownIssue17RegexPanic` asserted the panic and now asserts the rejection. That flip is the record of the fix.

**Not fixed:** there is still no uniform validation point, so a future flag with a fallible value depends on its author noticing. `forbidigo` narrows that to "not via `MustCompile`"; closing it properly needs the error-flow restructuring in #55.

Related:
- Closes https://github.com/korya/http-assert/issues/17
- https://github.com/korya/http-assert/issues/55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

