### PR TITLE
Add --version and publish release binaries on tag push

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,3 +37,12 @@ jobs:
 
     - name: Run end-to-end tests
       run: just test-e2e
+
+    # The release configuration is otherwise only exercised when a tag is
+    # pushed, which is the worst moment to discover it is broken. Cross-compiles
+    # every published target and publishes nothing.
+    - name: Build the release artifacts
+      uses: goreleaser/goreleaser-action@v7
+      with:
+        version: '~> v2'
+        args: build --snapshot --clean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:
@@ -16,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.24.4
+        go-version-file: go.mod
 
     - name: Install just
       uses: extractions/setup-just@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags: [ 'v*' ]
+
+permissions:
+  contents: write
+
+jobs:
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # goreleaser builds the changelog from the range between this tag and
+        # the previous one, which a shallow clone does not contain.
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Install just
+      uses: extractions/setup-just@v3
+
+    # A tag can be cut from any commit, not only one that master already proved
+    # green. Twenty seconds here is cheaper than a published binary that does
+    # not work and a version number that cannot be reused.
+    - name: Run end-to-end tests
+      run: just test-e2e
+
+    - name: Publish the release
+      uses: goreleaser/goreleaser-action@v7
+      with:
+        version: '~> v2'
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*.sw[a-z]
 http-assert
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,42 @@
+version: 2
+
+builds:
+  - id: http-assert
+    # A tool whose job is to run inside pipelines and scratch images has no
+    # business linking against a libc that might not be there.
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    # main.version is the release identity; without it the binary falls back to
+    # the pseudo-version Go derives from the commit, which is accurate but not
+    # the tag anybody asked for. The v prefix keeps a downloaded binary saying
+    # the same thing as one from `go install ...@v0.1.0`.
+    #
+    # .Version rather than .Tag: in snapshot mode .Tag is the *previous* tag, so
+    # stamping it would have a snapshot build claim to be a release it is not.
+    ldflags:
+      - -s -w -X main.version=v{{ .Version }}
+    # Reproducible builds: without this the archive timestamp is "now", so two
+    # builds of the same commit produce different checksums.
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  use: github

--- a/Justfile
+++ b/Justfile
@@ -98,7 +98,7 @@ test-cover-func:
 
 [doc("Clean build artifacts")]
 clean:
-    rm -f http-assert coverage.out coverage.html
+    rm -rf http-assert coverage.out coverage.html dist
 
 [doc("Install the binary to $GOPATH/bin")]
 install:
@@ -116,6 +116,13 @@ deps-update:
 [doc("Download dependencies")]
 deps-download:
     go mod download
+
+[doc("Build the release artifacts locally without publishing anything")]
+release-snapshot:
+    # Exercises the whole release pipeline -- cross-compilation, archives,
+    # checksums -- against the working tree. Publishes nothing and needs no
+    # tag, so it is safe to run at any point.
+    goreleaser release --snapshot --clean
 
 [doc("Run every check CI runs, including the end-to-end suite")]
 pre-push: pre-commit test-e2e

--- a/README.md
+++ b/README.md
@@ -14,6 +14,28 @@ A command-line tool for performing HTTP requests and asserting properties of the
 
 ## Installation
 
+### Download a Release Binary
+
+No Go toolchain required. Static binaries for Linux, macOS and Windows on
+amd64 and arm64 are attached to every [release](https://github.com/korya/http-assert/releases).
+
+```bash
+VERSION=v0.1.0
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')
+ARCHIVE="http-assert_${VERSION#v}_${OS}_${ARCH}.tar.gz"
+BASE="https://github.com/korya/http-assert/releases/download/$VERSION"
+
+curl -sSLO "$BASE/$ARCHIVE"
+curl -sSLO "$BASE/checksums.txt"
+sha256sum --ignore-missing -c checksums.txt   # macOS: shasum -a 256 -c
+
+tar xzf "$ARCHIVE" http-assert
+```
+
+The binary is statically linked, so it drops straight into a `scratch` or
+`distroless` image with `COPY --from`.
+
 ### From Source
 
 ```bash
@@ -69,6 +91,21 @@ http-assert [flags] <URL>
 | `--verbose` | `-v` | Enable verbose logging |
 | `--silent` | `-s` | Only log errors |
 | `--log-level` | | Set log level (debug, info, warn, error) |
+
+### Other Options
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--version` | | Print the version, commit and build platform, then exit |
+| `--help` | `-h` | Print usage, then exit |
+
+```console
+$ http-assert --version
+http-assert version v0.1.0 (commit 4ffe282, built 2026-08-07T22:24:59Z, go1.25.5, linux/amd64)
+```
+
+A binary built from a checkout rather than a release reports the commit it was
+built from instead of a tag.
 
 ## Examples
 
@@ -226,7 +263,7 @@ Repeating `--maphost` on the command line accumulates as usual.
 
 ### Exit Codes
 
-- `0`: All assertions passed
+- `0`: All assertions passed, or `--version`/`--help` was requested
 - `93`: Failed to perform HTTP request or assertions failed
 - `103`: Invalid command line arguments or other errors
 

--- a/e2e_panic_test.go
+++ b/e2e_panic_test.go
@@ -72,8 +72,8 @@ func cliFlags(t *testing.T) []flagSpec {
 
 	// Guards against a --help format change turning this into a no-op that
 	// probes nothing and passes.
-	if len(out) < 19 {
-		t.Fatalf("parsed only %d flags from --help, expected at least 19 -- parser is stale", len(out))
+	if len(out) < 20 {
+		t.Fatalf("parsed only %d flags from --help, expected at least 20 -- parser is stale", len(out))
 	}
 
 	return out

--- a/e2e_version_test.go
+++ b/e2e_version_test.go
@@ -1,0 +1,66 @@
+package main_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The identity of the binary is the first thing anyone asks of a pinned CI
+// tool, so --version is part of the contract: it answers on stdout, it exits
+// zero, and it does so without being given a URL.
+//
+// The shape is pinned rather than the content. The suite builds the CLI from
+// whatever checkout it is running in, so the version is a release tag in a
+// release, a pseudo-version in a clone, and "(devel)" wherever Go stamps no
+// version control information at all. Two ways to meet that last one: `go run`,
+// which never stamps -- only `go build` and `go install` ask for it -- and a
+// linked git worktree, where .git is a file and Go stops looking.
+func versionLine(t *testing.T) *regexp.Regexp {
+	t.Helper()
+
+	re, err := regexp.Compile(
+		`^http-assert version \S+ \(.*go1\.[0-9.]+, [a-z0-9]+/[a-z0-9]+\)$`)
+	if err != nil {
+		t.Fatalf("bad version-line pattern: %s", err)
+	}
+	return re
+}
+
+func TestE2EVersion(t *testing.T) {
+	want := versionLine(t)
+
+	t.Run("reports an identity on stdout", func(t *testing.T) {
+		r := run(t, nil, "--version")
+		assertExit(t, r, exitOK)
+
+		got := strings.TrimSpace(r.Stdout)
+		if !want.MatchString(got) {
+			t.Fatalf("--version = %q, want a match for %s", got, want)
+		}
+		if r.Stderr != "" {
+			t.Fatalf("--version wrote to stderr: %q", r.Stderr)
+		}
+	})
+
+	// --version is asked before the URL argument is required. A tool that
+	// demanded its normal arguments to identify itself would be useless in the
+	// place the question is actually asked: a broken pipeline.
+	t.Run("needs no URL", func(t *testing.T) {
+		bare := run(t, nil)
+		if bare.ExitCode == exitOK {
+			t.Fatal("a bare invocation succeeded; the URL is supposed to be required")
+		}
+		assertExit(t, run(t, nil, "--version"), exitOK)
+	})
+
+	// -v belongs to --verbose and must keep belonging to it; cobra hands the
+	// shorthand to --version whenever it finds it free.
+	t.Run("does not take the -v shorthand", func(t *testing.T) {
+		r := run(t, nil, "-v", "--assert-ok", url("/ok"))
+		assertExit(t, r, exitOK)
+		if want.MatchString(strings.TrimSpace(r.Stdout)) {
+			t.Fatalf("-v printed the version instead of enabling verbose logging\n%s", r.Output())
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -20,9 +20,10 @@ import (
 
 func main() {
 	cmd := &cobra.Command{
-		Use:   "http-assert <URL>",
-		Short: "Perform HTTP request and assert received HTTP response",
-		Args:  cobra.ExactArgs(1),
+		Use:     "http-assert <URL>",
+		Short:   "Perform HTTP request and assert received HTTP response",
+		Version: versionString(),
+		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			insecure, _ := cmd.Flags().GetBool("insecure")
 			maxTime, _ := cmd.Flags().GetInt("max-time")

--- a/version.go
+++ b/version.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"runtime"
+	"runtime/debug"
+	"strings"
+)
+
+// version is the release identity, stamped by goreleaser through
+// -ldflags "-X main.version=v<tag>". Every other way of obtaining this binary
+// leaves it empty and the identity is recovered from build information instead.
+var version = ""
+
+// versionString is what --version prints.
+func versionString() string {
+	bi, _ := debug.ReadBuildInfo()
+	return buildVersion(version, bi)
+}
+
+// buildVersion describes the binary from the release stamp and from the build
+// information Go embeds, preferring the stamp when both are available.
+//
+// The stamp on its own is not enough. Only the release build sets it, so
+// `go install ...@latest` -- the installation the README leads with -- would
+// report nothing at all. Go already knows the answer there: it records the
+// module version for a module install, and a pseudo-version plus the commit
+// and its timestamp for a build from a checkout.
+//
+// A field with nothing behind it is omitted rather than printed empty, which
+// is why a release names a commit and a module install does not. For a build
+// from a checkout the pseudo-version and the commit do overlap; that is
+// deliberate, because reading a seven-character revision beats picking one out
+// of a pseudo-version. bi is nil when the binary carries no build information.
+func buildVersion(stamped string, bi *debug.BuildInfo) string {
+	v, goVersion := stamped, runtime.Version()
+	var commit, built string
+
+	if bi != nil {
+		if v == "" {
+			v = bi.Main.Version
+		}
+		if bi.GoVersion != "" {
+			goVersion = bi.GoVersion
+		}
+
+		settings := make(map[string]string, len(bi.Settings))
+		for _, s := range bi.Settings {
+			settings[s.Key] = s.Value
+		}
+		if commit = settings["vcs.revision"]; commit != "" {
+			if len(commit) > shortRevisionLen {
+				commit = commit[:shortRevisionLen]
+			}
+			if settings["vcs.modified"] == "true" {
+				commit += "-dirty"
+			}
+		}
+		built = settings["vcs.time"]
+	}
+
+	if v == "" {
+		v = "unknown"
+	}
+
+	fields := make([]string, 0, 4)
+	if commit != "" {
+		fields = append(fields, "commit "+commit)
+	}
+	if built != "" {
+		fields = append(fields, "built "+built)
+	}
+	fields = append(fields, goVersion, runtime.GOOS+"/"+runtime.GOARCH)
+
+	return v + " (" + strings.Join(fields, ", ") + ")"
+}
+
+// shortRevisionLen is the git convention for an abbreviated revision.
+const shortRevisionLen = 7

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"runtime"
+	"runtime/debug"
+	"testing"
+)
+
+// platform is the tail every rendering ends with. It is built from the same
+// constants buildVersion uses, so these tests stay honest on any host.
+var platform = runtime.GOOS + "/" + runtime.GOARCH
+
+func settings(kv ...string) []debug.BuildSetting {
+	out := make([]debug.BuildSetting, 0, len(kv)/2)
+	for i := 0; i < len(kv); i += 2 {
+		out = append(out, debug.BuildSetting{Key: kv[i], Value: kv[i+1]})
+	}
+	return out
+}
+
+func Test_buildVersion(t *testing.T) {
+	const (
+		revision = "4ffe282a1b2c3d4e5f60718293a4b5c6d7e8f900"
+		when     = "2026-08-07T22:24:59Z"
+	)
+
+	tests := []struct {
+		Name    string
+		Stamped string
+		Info    *debug.BuildInfo
+		Want    string
+	}{{
+		// What a release binary reports: the tag from the stamp, the commit
+		// and timestamp from the checkout goreleaser built in.
+		Name:    "release build",
+		Stamped: "v0.1.0",
+		Info: &debug.BuildInfo{
+			Main:      debug.Module{Version: "(devel)"},
+			GoVersion: "go1.25.5",
+			Settings:  settings("vcs.revision", revision, "vcs.time", when, "vcs.modified", "false"),
+		},
+		Want: "v0.1.0 (commit 4ffe282, built " + when + ", go1.25.5, " + platform + ")",
+	}, {
+		// `go install github.com/korya/http-assert@v0.0.7`. The module version
+		// is authoritative and there is no VCS information to report.
+		Name: "module install",
+		Info: &debug.BuildInfo{
+			Main:      debug.Module{Version: "v0.0.7"},
+			GoVersion: "go1.25.5",
+		},
+		Want: "v0.0.7 (go1.25.5, " + platform + ")",
+	}, {
+		// `go build` in a checkout with uncommitted changes. Go synthesises a
+		// pseudo-version; the revision is marked so nobody mistakes the binary
+		// for the commit it names.
+		Name: "checkout build with local modifications",
+		Info: &debug.BuildInfo{
+			Main:      debug.Module{Version: "v0.0.8-0.20260807222459-4ffe282a1b2c+dirty"},
+			GoVersion: "go1.25.5",
+			Settings:  settings("vcs.revision", revision, "vcs.time", when, "vcs.modified", "true"),
+		},
+		Want: "v0.0.8-0.20260807222459-4ffe282a1b2c+dirty (commit 4ffe282-dirty, built " +
+			when + ", go1.25.5, " + platform + ")",
+	}, {
+		// A revision already short enough is passed through untouched.
+		Name: "revision shorter than the abbreviation",
+		Info: &debug.BuildInfo{
+			Main:      debug.Module{Version: "v0.0.7"},
+			GoVersion: "go1.25.5",
+			Settings:  settings("vcs.revision", "4ffe28"),
+		},
+		Want: "v0.0.7 (commit 4ffe28, go1.25.5, " + platform + ")",
+	}, {
+		// -buildvcs=false, or a build from an exported tree. Go reports the
+		// module as unversioned and stamps nothing.
+		Name: "no version control information",
+		Info: &debug.BuildInfo{
+			Main:      debug.Module{Version: "(devel)"},
+			GoVersion: "go1.25.5",
+		},
+		Want: "(devel) (go1.25.5, " + platform + ")",
+	}, {
+		// Neither source knows anything. Saying so beats printing an empty
+		// version that reads like a formatting bug.
+		Name: "nothing known",
+		Info: &debug.BuildInfo{},
+		Want: "unknown (" + runtime.Version() + ", " + platform + ")",
+	}, {
+		// debug.ReadBuildInfo fails. The stamp still carries the release.
+		Name:    "no build information, stamped",
+		Stamped: "v0.1.0",
+		Want:    "v0.1.0 (" + runtime.Version() + ", " + platform + ")",
+	}, {
+		Name: "no build information, unstamped",
+		Want: "unknown (" + runtime.Version() + ", " + platform + ")",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			if got := buildVersion(tc.Stamped, tc.Info); got != tc.Want {
+				t.Errorf("buildVersion() = %q, want %q", got, tc.Want)
+			}
+		})
+	}
+}
+
+// Test_versionString guards the wiring rather than the formatting: whatever the
+// test binary was built from, --version must have something to say.
+func Test_versionString(t *testing.T) {
+	if got := versionString(); got == "" {
+		t.Fatal("versionString() is empty")
+	}
+}


### PR DESCRIPTION
## Problem

You cannot install `http-assert` without a Go toolchain, and you cannot ask a copy of it what it is.

Both are the same wound. This is a tool built to be pinned in a pipeline step or dropped into a scratch container — precisely the places where compiling from source is absurd and where "which build is this?" is the first question asked when something breaks. Seven tags existed; nothing consumed them, no release was ever published, and `--version` was an error:

```console
$ http-assert --version
Error: unknown flag: --version
[exit=103]
```

## Solution

Pushing a `v*` tag now publishes a GitHub Release, and every binary can name itself.

Identity comes from the build information Go already embeds, with the release stamp as an override — so `go install …@latest`, a clone, and a downloaded release all answer, rather than only the one path a link-time stamp reaches:

```console
$ http-assert --version                       # a release
http-assert version v0.1.0 (commit 4ffe282, built 2026-08-07T22:24:59Z, go1.25.5, linux/amd64)

$ http-assert --version                       # go install …@v0.0.7
http-assert version v0.0.7 (go1.25.5, darwin/arm64)
```

A tag produces static binaries for five platforms, archives carrying the README and licence, a verifiable `checksums.txt`, and notes generated from the commit range. The end-to-end suite gates the publish, because a tag can be cut from any commit and a broken binary burns a version number permanently.

The release path is not taken on trust. `just release-snapshot` runs the whole pipeline locally against the working tree, publishing nothing; CI cross-compiles every target on each pull request, so a broken configuration surfaces on the change that caused it instead of at the moment a tag goes public.

Coverage stays at 100.0%: the rendering is a pure function over its two sources, so the paths no test host can produce — no VCS information, no build information at all — are still reachable from a unit test.

Two things cobra does quietly are pinned by the suite rather than assumed: `--version` is answered before the URL argument becomes required, and `-v` stays with `--verbose` instead of being claimed as a shorthand.

## Other Changes

- CI asked for Go 1.24.4 while `go.mod` required 1.25.5, so every run silently downloaded a second toolchain. Fine for a test job; not fine for one whose output people download.
- Dependabot watched `go.mod` and nothing else, so the actions the release now depends on would have aged silently.
- The exit-code table said `0` meant every assertion passed — no longer the whole truth once a flag can succeed without running any.
- Least-privilege `permissions:` on both workflows.

No new runtime dependencies; goreleaser never enters `go.mod`.

## Notes for the reviewer

Nothing is released by merging this. The first tag is yours to cut, and `v0.1.0` rather than `v0.0.8` is the intent: since `v0.0.7` a malformed `HTTP_ASSERT_MAX_TIME` went from silently coercing to zero — that is, no timeout at all — to exiting 71.

Not included, deliberately: a GHCR image (its own tag policy and auth), build-provenance attestations, and a cross-OS *test* matrix — the snapshot build proves the code compiles for darwin and windows, not that it works there.

Closes #38
Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)
