### PR TITLE
Document the command in the package comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,10 @@ Repeating `--maphost` on the command line accumulates as usual.
 ### Exit Codes
 
 - `0`: All assertions passed, or `--version`/`--help` was requested
-- `93`: Failed to perform HTTP request or assertions failed
-- `103`: Invalid command line arguments or other errors
+- `71`: A flag or environment value failed to parse
+- `91`: The request could not be constructed from the method and URL
+- `93`: Failed to perform HTTP request, or at least one assertion failed
+- `103`: Wrong argument count, or an unknown flag
 
 ## Use Cases
 

--- a/main.go
+++ b/main.go
@@ -1,3 +1,40 @@
+// Command http-assert performs an HTTP request and asserts properties of the
+// response, exiting non-zero when an assertion fails.
+//
+// It is built for the places where a failing exit code is the whole point: a
+// pipeline step, a container healthcheck, a monitoring script. Assertions are
+// declared as flags, and the request is made once and checked against all of
+// them.
+//
+//	http-assert --assert-ok https://example.com
+//	http-assert --assert-status 201 -X POST -d '{"n":1}' https://api.example.com/things
+//	http-assert --assert-header 'Content-Type: application/json' \
+//		--assert-body '"ok":true' https://api.example.com/health
+//
+// # Exit codes
+//
+// The exit code is the result. Distinguishing a failed assertion from a tool
+// that could not run is what lets a pipeline tell a broken service from a
+// broken invocation.
+//
+//	0    every assertion passed
+//	71   a flag or environment value failed to parse
+//	91   the request could not be constructed from the method and URL
+//	93   the request failed, or at least one assertion did
+//	103  wrong argument count, or an unknown flag
+//
+// # Environment
+//
+// Six options also read the environment, as HTTP_ASSERT_<NAME> with dashes
+// replaced by underscores: --verbose, --silent, --log-level, --insecure,
+// --max-time and --maphost. The command line wins over the environment, which
+// wins over the default. A value that does not parse is rejected rather than
+// coerced, so a typo fails loudly instead of silently disabling the option it
+// was meant to set.
+//
+// The remaining options are command-line only. Repeatable options split one
+// variable on whitespace, which suits host mappings and would corrupt header
+// values.
 package main
 
 import (


### PR DESCRIPTION
## Problem

pkg.go.dev says there is no documentation for this package, and the README links to that page with a badge.

Measured against the currently-indexed `v0.0.7`, the page renders exactly one thing:

```
"There is no documentation for this package": True
```

`main.go` opened with a bare `package main`, and pkg.go.dev renders a command's doc comment or nothing at all. So the Go Reference badge on line 1 of the README has been advertising documentation that does not exist.

## Solution

Write the package comment, and make the README agree with it about exit codes.

The comment covers the four things somebody arriving from that badge is trying to learn: what the tool is for, the shape of an invocation, the exit codes, and which options read the environment. Every example in it was run against a live endpoint before being written down, and each documented exit code was reproduced:

```console
$ http-assert --log-level nope --assert-ok https://example.com   # exit=71
$ http-assert -X 'BAD METHOD' --assert-ok https://example.com    # exit=91
$ http-assert --assert-ok                                        # exit=103
```

Writing those down exposed that the README listed three of the five. `71` has been returned since unparseable environment values started being rejected, and `91` for as long as a malformed method or URL has been possible — neither was ever documented. That gap is worse than a missing table row: a monitoring script that reads every non-zero code as "the service is down" reports a typo in `HTTP_ASSERT_MAX_TIME` as an outage, which inverts the tool's purpose.

Documentation only — no behaviour change, and the end-to-end suite is untouched.

## Other Changes

None.

## Notes for the reviewer

This lands on the next tag, not retroactively on `v0.1.0`; pkg.go.dev renders whatever the tagged commit contained.

The exit codes now appear in three places — the package comment, the README, and `e2e_harness_test.go`'s constants. Only the last is enforced. Worth an issue if the duplication bothers you; I did not want to invent a doc-linting mechanism inside a docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
