### PR TITLE
Make --help and the README describe what the tool actually does

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ http-assert [flags] <URL>
 
 | Flag | Description |
 |------|-------------|
-| `--assert-ok` | Assert 2xx status code |
+| `--assert-ok` | Assert the status is not an error (2xx or 3xx) |
 | `--assert-status` | Assert specific status code |
 | `--assert-header` | Assert header matches regex pattern |
 | `--assert-header-eq` | Assert header equals exact value |
@@ -237,6 +237,10 @@ http-assert --assert-ok https://api.example.com
 **The remaining options are command-line only.** `--request`, `--header`, `--data` and every `--assert-*` flag ignore the environment; setting `HTTP_ASSERT_REQUEST=POST` has no effect.
 
 **A command-line flag always wins over the environment**, which in turn wins over the built-in default. An empty variable counts as unset.
+
+#### Proxies
+
+`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are honoured for the request itself, through Go's standard proxy resolution. There is no flag for them, and no way to disable the behaviour from the command line — if one of these is set in your environment for unrelated reasons, requests go through it.
 
 **A value that does not parse is rejected** rather than ignored, so a typo cannot silently change behaviour:
 

--- a/e2e_help_test.go
+++ b/e2e_help_test.go
@@ -1,0 +1,65 @@
+package main_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// --help is the only reference available at the terminal, and the two things
+// this tool's callers most need from it -- what the exit code will be, and
+// what can be set without touching the command line -- were the two things it
+// never mentioned (#39).
+//
+// The exit codes live in four places now: here, the README, the package
+// comment, and the constants in the harness. Prose cannot be generated from
+// the constants, so this test does the next best thing and fails when they
+// stop agreeing.
+
+func TestE2EHelpDocumentsTheContract(t *testing.T) {
+	r := run(t, nil, "--help")
+	assertExit(t, r, exitOK)
+
+	t.Run("every exit code the CLI can return is listed", func(t *testing.T) {
+		for _, code := range []int{exitOK, exitBadFlagVal, exitBadRequest, exitRequestFail, exitUsage} {
+			if !strings.Contains(r.Output(), fmt.Sprintf("\n  %d ", code)) {
+				t.Errorf("--help does not document exit code %d", code)
+			}
+		}
+	})
+
+	// Exit 2 was the Go panic path. #61 removed it and TestE2ENoFlagPanics
+	// keeps it removed, so it is deliberately absent rather than overlooked.
+	t.Run("the panic exit code is not advertised", func(t *testing.T) {
+		if strings.Contains(r.Output(), "\n  2 ") {
+			t.Error("--help documents exit code 2, which the CLI can no longer return")
+		}
+	})
+
+	t.Run("every environment-backed option is named", func(t *testing.T) {
+		for _, tc := range envSupportedCases(t) {
+			if !strings.Contains(r.Output(), tc.EnvKey) {
+				t.Errorf("--help does not mention %s", tc.EnvKey)
+			}
+		}
+	})
+
+	// Proxying works through the transport's environment defaults and has no
+	// flag, so --help is the only place a user could learn it exists (#46).
+	t.Run("proxy support is discoverable", func(t *testing.T) {
+		for _, name := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
+			if !strings.Contains(r.Output(), name) {
+				t.Errorf("--help does not mention %s", name)
+			}
+		}
+	})
+
+	// The flag list is found by cutting the help output at "Flags:", so that
+	// string appearing in the prose above would silently point the parser at
+	// the wrong section -- and a probe that reads no flags passes.
+	t.Run("prose does not shadow the flag section", func(t *testing.T) {
+		if n := strings.Count(r.Output(), "Flags:"); n != 1 {
+			t.Fatalf("help output contains %d occurrences of \"Flags:\", want exactly 1", n)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -100,13 +100,15 @@ func main() {
 	cmd.PersistentFlags().StringArray("maphost", nil,
 		"Provide a custom address for a specific host and port pair; "+
 			"e.g. <srchostname:srcport=dsthostname[:dstport]>")
-	cmd.PersistentFlags().BoolP("verbose", "v", false, "Be verbose; log info messages")
-	cmd.PersistentFlags().BoolP("silent", "s", false, "Be silent; log errors only")
+	cmd.PersistentFlags().BoolP("verbose", "v", false,
+		"Be verbose; log debug messages (same as --log-level debug)")
+	cmd.PersistentFlags().BoolP("silent", "s", false,
+		"Be silent; log error messages only (same as --log-level error)")
 	cmd.PersistentFlags().String("log-level", "",
 		"Set log level; possible values: debug, info (default), warn, error")
 	cmd.PersistentFlags().BoolP("insecure", "k", false, "Disable checking SSL certificates")
 	cmd.PersistentFlags().IntP("max-time", "m", 20,
-		"Maximum  time  in seconds that you allow each request to take")
+		"Maximum time in seconds that you allow each request to take")
 	cmd.Flags().StringP("request", "X", "GET", "Set method for HTTP request")
 	cmd.Flags().StringArrayP("header", "H", nil, "Set header for HTTP request")
 	cmd.Flags().StringP("data", "d", "",
@@ -254,17 +256,22 @@ func parseHostMappings(vals []string) ([]hostMapping, error) {
 
 func registerAssertionFlags(cmd *cobra.Command) {
 	cmd.Flags().Int("assert-status", 0, "Assert response status equals the provided value")
-	cmd.Flags().StringArray("assert-header", nil, "Assert header equals the provided regexp")
-	cmd.Flags().StringArray("assert-header-eq", nil, "Assert header equals the provided regexp")
+	cmd.Flags().StringArray("assert-header", nil,
+		"Assert header matches the provided regexp; NAME alone asserts it is present")
+	cmd.Flags().StringArray("assert-header-eq", nil,
+		"Assert header equals the provided value; NAME alone asserts it is present")
 	cmd.Flags().StringArray("assert-header-missing", nil, "Assert header is missing")
-	cmd.Flags().String("assert-body", "", "Assert body equals the provided value")
+	cmd.Flags().String("assert-body", "", "Assert body matches the provided regexp")
 	cmd.Flags().String("assert-body-eq", "", "Assert body equals the provided value")
 	cmd.Flags().Bool("assert-body-empty", false, "Assert body is empty")
 
 	// Common shorthands
-	cmd.Flags().Bool("assert-ok", false, "Assert response is successful (2xx)")
-	cmd.Flags().String("assert-redirect", "", "Assert response redirects to the provided URL")
-	cmd.Flags().String("assert-redirect-eq", "", "Assert response redirects to the provided URL")
+	cmd.Flags().Bool("assert-ok", false,
+		"Assert response status is not an error (2xx or 3xx)")
+	cmd.Flags().String("assert-redirect", "",
+		"Assert redirect location matches the provided regexp")
+	cmd.Flags().String("assert-redirect-eq", "",
+		"Assert redirect location equals the provided URL")
 }
 
 // mustCompileAssertion builds a pattern-based assertion, reporting an

--- a/main.go
+++ b/main.go
@@ -58,8 +58,48 @@ import (
 
 func main() {
 	cmd := &cobra.Command{
-		Use:     "http-assert <URL>",
-		Short:   "Perform HTTP request and assert received HTTP response",
+		Use:   "http-assert <URL>",
+		Short: "Perform HTTP request and assert received HTTP response",
+		// The exit code is the whole product, so it is documented where a
+		// person actually looks for it. The environment is here for the same
+		// reason: nothing else at the terminal reveals that six of these
+		// options can be set without touching the command line.
+		//
+		// Careful with the wording below: the end-to-end suite locates the
+		// flag list by cutting this output at the first "Flags:", so that
+		// exact string must not appear here (see e2e_panic_test.go).
+		Long: `Perform an HTTP request and assert properties of the response.
+
+Assertions are declared as flags. The request is made once and checked
+against all of them, and every failure is reported, not just the first.
+
+Exit codes:
+  0    every assertion passed
+  71   a flag or environment value failed to parse
+  91   the request could not be constructed from the method and URL
+  93   the request failed, or at least one assertion did
+  103  wrong argument count, or an unknown flag
+
+Environment:
+  Six options can also be set as HTTP_ASSERT_<NAME>, with dashes replaced by
+  underscores: HTTP_ASSERT_VERBOSE, HTTP_ASSERT_SILENT, HTTP_ASSERT_LOG_LEVEL,
+  HTTP_ASSERT_INSECURE, HTTP_ASSERT_MAX_TIME and HTTP_ASSERT_MAPHOST. Every
+  other option is command-line only.
+
+  The command line wins over the environment, which wins over the default. An
+  empty variable counts as unset, and a value that does not parse is rejected
+  rather than quietly replaced by a zero.
+
+  HTTP_PROXY, HTTPS_PROXY and NO_PROXY are honoured for the request itself.
+  There is no flag for them.`,
+		Example: `  # A health check: any non-error status passes
+  http-assert --assert-ok https://example.com/health
+
+  # Exact status plus a body pattern
+  http-assert --assert-status 201 --assert-body '"id":\s*[0-9]+' https://example.com/things
+
+  # Send a request to a specific backend, as curl --resolve does
+  http-assert --maphost 'example.com:443=127.0.0.1:8443' --assert-ok https://example.com/`,
 		Version: versionString(),
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Problem

Every reference the tool offers disagreed with the tool.

`--help` could not be used to tell the regexp assertions from the exact-match ones — the single most important distinction in the flag set. `--assert-header` and `--assert-header-eq` carried *identical* text, as did `--assert-redirect` and `--assert-redirect-eq`, and `--assert-body` advertised an equality check it has never performed.

`--assert-ok` claimed "successful (2xx)" while passing anything below 400. Verified against a live endpoint:

```console
$ http-assert --assert-ok http://github.com
[:] HTTP/1.1 301 Moved Permanently
[+] PASSED                                    # exit 0
```

`-v` said it logs info and selects debug; `-s` said it filters and selects error. `-m` carried double spaces imported from curl's man page, where they were troff formatting.

And `--help` never mentioned the exit code — the tool's entire output — nor the six options settable from the environment, nor that the transport already honours `HTTP_PROXY`:

```console
$ http-assert --help | grep -icE 'HTTP_ASSERT|exit code|proxy'
0
```

## Solution

Descriptions now name the range, level or match semantics they actually implement, and `--help` grew a section covering exit codes, the `HTTP_ASSERT_*` variables with their precedence, and proxy support.

The 2xx-or-3xx behaviour is documented rather than narrowed. `Test_AssertStatusOK` pins 300, 301, 307 and 399 as OK, so it is intentional — curl `-f` semantics. Worth knowing that since redirects are not followed, a health check aimed at an endpoint that starts redirecting to a login page stays green.

Both header assertions fall back to a presence check when handed a bare name, which the descriptions now say — it is also why asserting a header equals the empty string is not expressible.

A new end-to-end test pins the help text against the harness's own exit-code constants rather than against literals, so the four places these codes now live cannot drift apart quietly. Both of its failure modes were confirmed by mutation before commit, because a guard that has never failed is not a guard.

## Other Changes

Exit code `2` is deliberately **not** documented, contrary to what #24 asked for. It was the Go panic path; #61 removed it and the hostile-input probe keeps it removed, so listing it would document something that can no longer happen. The test asserts its absence.

`#24`'s remaining item — `93` conflating "service down" with "service wrong" — is a behaviour change and moved to #71.

## Notes for the reviewer

The `Long` text carries a trap worth knowing about: the flag-panic probe locates the flag list by cutting `--help` at the first `"Flags:"`, so that string appearing in the prose above would silently point it at the wrong section — and a probe that reads no flags is a probe that passes. The new test asserts there is exactly one occurrence.

The README's assertion table was already correct about regexp vs exact matching; only its `--assert-ok` row was wrong. #37 is narrower than filed — a `--help`-only bug.

Closes #20
Closes #24
Closes #30
Closes #37
Closes #39
Closes #40
Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)