### PR TITLE
Reject a repeated assertion flag instead of dropping the earlier one

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ http-assert [flags] <URL>
 | `--assert-redirect` | Assert redirect location matches regex |
 | `--assert-redirect-eq` | Assert redirect location equals exact value |
 
+The three header flags can be repeated to make several assertions of that kind. Every other assertion flag takes a single value; giving one twice exits `71` rather than silently keeping the last.
+
 ### Logging Options
 
 | Flag | Short | Description |
@@ -268,7 +270,7 @@ Repeating `--maphost` on the command line accumulates as usual.
 ### Exit Codes
 
 - `0`: All assertions passed, or `--version`/`--help` was requested
-- `71`: A flag or environment value failed to parse
+- `71`: A flag or environment value was rejected
 - `91`: The request could not be constructed from the method and URL
 - `93`: Failed to perform HTTP request, or at least one assertion failed
 - `103`: Wrong argument count, or an unknown flag

--- a/e2e_panic_test.go
+++ b/e2e_panic_test.go
@@ -40,6 +40,7 @@ var hostileValues = []string{
 // flagSpec is one flag as advertised by --help.
 type flagSpec struct {
 	Name     string // long name, without dashes
+	Type     string // the value type --help prints, empty for a boolean
 	TakesArg bool   // whether --help shows a value type after it
 }
 
@@ -67,7 +68,7 @@ func cliFlags(t *testing.T) []flagSpec {
 		if m == nil || m[1] == "help" {
 			continue
 		}
-		out = append(out, flagSpec{Name: m[1], TakesArg: m[2] != ""})
+		out = append(out, flagSpec{Name: m[1], Type: m[2], TakesArg: m[2] != ""})
 	}
 
 	// Guards against a --help format change turning this into a no-op that

--- a/e2e_repeat_test.go
+++ b/e2e_repeat_test.go
@@ -1,0 +1,80 @@
+package main_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// Repeating an assertion flag used to depend on how the flag happened to be
+// declared: the header flags accumulated, everything else silently kept the
+// last value and threw the rest away. A run could go green having checked less
+// than it was asked to, which is the worst thing a test tool can do (#35).
+//
+// The flag list comes from --help rather than a table here, so an assertion
+// flag added later is held to the same rule the day it is added -- the absence
+// of exactly that link is what let the two groups drift apart originally.
+
+// accumulates mirrors the rule the CLI applies, using the type --help prints.
+func accumulates(flagType string) bool {
+	return strings.HasSuffix(flagType, "Array") || strings.HasSuffix(flagType, "Slice")
+}
+
+func TestE2ERepeatedAssertionFlags(t *testing.T) {
+	// The config matrix already knows a valid invocation for every option,
+	// including which endpoint makes that assertion meaningful.
+	args := make(map[string]configCase, len(configCases(t)))
+	for _, tc := range configCases(t) {
+		args[tc.Flag] = tc
+	}
+
+	var checked int
+	for _, f := range cliFlags(t) {
+		if !strings.HasPrefix(f.Name, "assert-") {
+			continue
+		}
+
+		tc, ok := args[f.Name]
+		if !ok {
+			t.Fatalf("--%s is advertised by --help but absent from the config matrix; add it there", f.Name)
+		}
+		checked++
+
+		t.Run(f.Name, func(t *testing.T) {
+			// The same option, twice, then whatever target makes it meaningful.
+			var argv []string
+			argv = append(argv, tc.CLI...)
+			argv = append(argv, tc.CLI...)
+			argv = append(argv, tc.Base...)
+
+			r := run(t, nil, argv...)
+
+			if accumulates(f.Type) {
+				// Repeating these is the documented way to make several
+				// assertions, so it must not be an error.
+				if r.ExitCode == exitBadFlagVal {
+					t.Fatalf("--%s (%s) rejected a repeat, but repeating it is how you add assertions\n%s",
+						f.Name, f.Type, r.Output())
+				}
+				return
+			}
+
+			assertExit(t, r, exitBadFlagVal)
+			assertContains(t, r, "--"+f.Name+" was given 2 times")
+		})
+	}
+
+	// Guards against the --help parser or the prefix test quietly matching
+	// nothing, which would leave this passing while checking no flag at all.
+	if checked < 10 {
+		t.Fatalf("checked only %d assertion flags, expected at least 10 -- the enumeration is stale", checked)
+	}
+}
+
+// The contradiction in the issue: two --assert-status values, where the first
+// would have failed. It used to exit 0, having run only the second.
+func TestE2ERepeatedAssertionKeepsNothingSilently(t *testing.T) {
+	r := run(t, nil, "--assert-status", "500", "--assert-status", "200", url("/ok"))
+
+	assertExit(t, r, exitBadFlagVal)
+	assertNotContains(t, r, "PASSED")
+}

--- a/flags_test.go
+++ b/flags_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func Test_collects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Type string
+		Want bool
+	}{
+		{"string", false},
+		{"int", false},
+		{"bool", false},
+		{"stringArray", true},
+		{"stringSlice", true},
+		{"intSlice", true},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Type, func(t *testing.T) {
+			if got := collects(tc.Type); got != tc.Want {
+				t.Errorf("collects(%q) = %v, want %v", tc.Type, got, tc.Want)
+			}
+		})
+	}
+}
+
+// Test_singleValue checks the wrapper stays invisible to everything except the
+// count. pflag reads a flag back through String() and dispatches on Type(), so
+// a wrapper that got either wrong would break --help and GetInt rather than
+// catching a repeat.
+func Test_singleValue(t *testing.T) {
+	t.Parallel()
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.Int("n", 7, "")
+	v := &singleValue{inner: fs.Lookup("n").Value}
+	fs.Lookup("n").Value = v
+
+	if got, want := v.String(), "7"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+	if got, want := v.Type(), "int"; got != want {
+		t.Errorf("Type() = %q, want %q", got, want)
+	}
+	if v.count != 0 {
+		t.Errorf("count = %d before any assignment, want 0", v.count)
+	}
+
+	if err := fs.Parse([]string{"--n", "1", "--n", "2"}); err != nil {
+		t.Fatalf("parse: %s", err)
+	}
+
+	if v.count != 2 {
+		t.Errorf("count = %d after two occurrences, want 2", v.count)
+	}
+	if got, want := v.String(), "2"; got != want {
+		t.Errorf("String() = %q, want %q -- the wrapper must not disturb the value", got, want)
+	}
+
+	// The reason the wrapper exists: pflag's own record cannot tell these apart.
+	if !fs.Changed("n") {
+		t.Error("Changed() = false after two occurrences")
+	}
+
+	// And the value is still readable through pflag's typed accessor, which
+	// dispatches on Type() and parses String().
+	if got, err := fs.GetInt("n"); err != nil || got != 2 {
+		t.Errorf("GetInt() = %d, %v; want 2, nil", got, err)
+	}
+}
+
+func Test_rejectRepeats(t *testing.T) {
+	t.Parallel()
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.Int("assert-status", 0, "")
+	fs.String("assert-body", "", "")
+	fs.Bool("assert-ok", false, "")
+	fs.StringArray("assert-header", nil, "")
+	fs.String("request", "GET", "")
+
+	rejectRepeats(fs)
+
+	tests := []struct {
+		Name    string
+		Wrapped bool
+		Why     string
+	}{
+		{"assert-status", true, "single-valued assertion"},
+		{"assert-body", true, "single-valued assertion"},
+		{"assert-ok", true, "a repeated bool flips the assertion rather than adding one"},
+		{"assert-header", false, "repeating it is how you add assertions"},
+		{"request", false, "not an assertion; last-wins is conventional for configuration"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, wrapped := fs.Lookup(tc.Name).Value.(*singleValue)
+			if wrapped != tc.Wrapped {
+				t.Errorf("--%s wrapped = %v, want %v (%s)", tc.Name, wrapped, tc.Wrapped, tc.Why)
+			}
+		})
+	}
+}
+
+// Test_checkRepeats_allows covers the path that must not terminate. The path
+// that does call dief exits the process, so it is exercised by the end-to-end
+// suite against the real binary instead.
+func Test_checkRepeats_allows(t *testing.T) {
+	t.Parallel()
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.Int("assert-status", 0, "")
+	fs.StringArray("assert-header", nil, "")
+	rejectRepeats(fs)
+
+	if err := fs.Parse([]string{"--assert-status", "1", "--assert-header", "a", "--assert-header", "b"}); err != nil {
+		t.Fatalf("parse: %s", err)
+	}
+
+	checkRepeats(fs) // must return; a repeated collecting flag is legitimate
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,10 @@
 // declared as flags, and the request is made once and checked against all of
 // them.
 //
+// The three header assertions can be repeated to assert several things at
+// once. Every other assertion flag takes a single value and is rejected if
+// given twice, rather than quietly keeping the last one.
+//
 //	http-assert --assert-ok https://example.com
 //	http-assert --assert-status 201 -X POST -d '{"n":1}' https://api.example.com/things
 //	http-assert --assert-header 'Content-Type: application/json' \
@@ -18,7 +22,7 @@
 // broken invocation.
 //
 //	0    every assertion passed
-//	71   a flag or environment value failed to parse
+//	71   a flag or environment value was rejected
 //	91   the request could not be constructed from the method and URL
 //	93   the request failed, or at least one assertion did
 //	103  wrong argument count, or an unknown flag
@@ -73,9 +77,13 @@ func main() {
 Assertions are declared as flags. The request is made once and checked
 against all of them, and every failure is reported, not just the first.
 
+Repeat --assert-header, --assert-header-eq or --assert-header-missing to make
+several assertions of that kind. Every other assertion flag takes a single
+value and is rejected if given twice, rather than quietly keeping the last.
+
 Exit codes:
   0    every assertion passed
-  71   a flag or environment value failed to parse
+  71   a flag or environment value was rejected
   91   the request could not be constructed from the method and URL
   93   the request failed, or at least one assertion did
   103  wrong argument count, or an unknown flag

--- a/main.go
+++ b/main.go
@@ -154,8 +154,12 @@ Environment:
 	cmd.Flags().StringP("data", "d", "",
 		"Sends the specified data in a POST request to the HTTP server")
 	registerAssertionFlags(cmd)
+	rejectRepeats(cmd.Flags())
 
 	cmd.PersistentPreRun = func(cmd *cobra.Command, _ []string) {
+		// Before applyEnv, so that a value the environment supplies can never
+		// be mistaken for a second occurrence on the command line.
+		checkRepeats(cmd.Flags())
 		applyEnv(cmd.Flags())
 	}
 
@@ -312,6 +316,55 @@ func registerAssertionFlags(cmd *cobra.Command) {
 		"Assert redirect location matches the provided regexp")
 	cmd.Flags().String("assert-redirect-eq", "",
 		"Assert redirect location equals the provided URL")
+}
+
+// singleValue wraps a flag that holds one value, counting how many times the
+// parser assigned to it.
+//
+// pflag records only whether a flag was set, never how often, so a second
+// occurrence of a scalar flag overwrites the first and leaves nothing behind
+// to notice. For an assertion that means the run goes green having checked
+// less than it was asked to (#35). The count is the missing evidence.
+type singleValue struct {
+	inner pflag.Value
+	count int
+}
+
+func (v *singleValue) Set(s string) error { v.count++; return v.inner.Set(s) }
+func (v *singleValue) String() string     { return v.inner.String() }
+func (v *singleValue) Type() string       { return v.inner.Type() }
+
+// collects reports whether a flag type accumulates its values rather than
+// replacing them. Repeating those is how you ask for several assertions.
+func collects(flagType string) bool {
+	return strings.HasSuffix(flagType, "Array") || strings.HasSuffix(flagType, "Slice")
+}
+
+// rejectRepeats prepares every single-valued assertion flag to notice a repeat.
+//
+// Derived from the flag's own type rather than a list, because a list is how
+// this went wrong in the first place: --assert-header was made repeatable and
+// the others were not, and nothing connected the two decisions. An assertion
+// flag added later is covered the day it is added.
+func rejectRepeats(fs *pflag.FlagSet) {
+	fs.VisitAll(func(f *pflag.Flag) {
+		if strings.HasPrefix(f.Name, "assert-") && !collects(f.Value.Type()) {
+			f.Value = &singleValue{inner: f.Value}
+		}
+	})
+}
+
+// checkRepeats terminates when an assertion was named more than once. Taking
+// the last value silently is the one outcome worth refusing: the alternative
+// is a tool that reports success for a check it never ran.
+func checkRepeats(fs *pflag.FlagSet) {
+	fs.VisitAll(func(f *pflag.Flag) {
+		if v, ok := f.Value.(*singleValue); ok && v.count > 1 {
+			dief(71, "Flag --%s was given %d times but accepts a single value; "+
+				"repeat --assert-header, --assert-header-eq or --assert-header-missing "+
+				"to make several assertions", f.Name, v.count)
+		}
+	})
 }
 
 // mustCompileAssertion builds a pattern-based assertion, reporting an


### PR DESCRIPTION
## Problem

Repeating an assertion silently threw one away, and the run went green anyway.

```console
$ http-assert --assert-status 500 --assert-status 200 http://…/ok
[+] PASSED                     # exit 0 — the 500 was never checked
```

Which of the two things happens depends on how the flag was declared. The three header flags accumulate, so repeating them adds assertions. Every other assertion flag keeps the last value and discards the rest, without a word. Nothing in the flag names distinguishes the two groups.

For a tool whose entire output is an exit code, reporting success for a check it never ran is the worst failure mode available — and the caller cannot detect it.

**Seven flags were affected, not the one reported.** The booleans lose information too:

```console
$ http-assert --assert-ok --assert-ok=false http://…/ok
                               # silently inverted to "assert NOT ok"

$ http-assert --assert-body-empty --assert-body-empty=false http://…/ok
Error: Cannot perform request: no assertions defined
```

That last message is the bug in one line: the user named an assertion twice and was told there are none.

## Solution

Repeating a single-valued assertion now exits `71` and says so:

```console
$ http-assert --assert-status 500 --assert-status 200 http://…/ok
Error: Flag --assert-status was given 2 times but accepts a single value;
repeat --assert-header, --assert-header-eq or --assert-header-missing to make several assertions
```

pflag records *whether* a flag was set but never *how often*, so the count is gathered by wrapping each affected flag's `Value`. Which flags get wrapped is derived from the flag's own type rather than a hardcoded list — a list is precisely how this went wrong, since `--assert-header` was made repeatable, the others were not, and nothing connected the two decisions. An assertion flag added later is covered the day it is added.

The check runs before `applyEnv`, so a value arriving from the environment can never be counted as a second occurrence on the command line.

The end-to-end guard enumerates the assertion flags from `--help` and holds each to the rule its type implies, reusing the existing config matrix for a valid invocation of each. Both of its failure modes — a flag escaping the wrapping, and the enumeration silently matching nothing — were confirmed by mutation before commit. Coverage stays at 100.0%.

## Other Changes

Exit `71` was documented as "a flag or environment value failed to parse", which a repeated flag is not — the value parsed fine, there were simply two of them. Reworded in all three places it appears, and the repeatable-vs-single distinction is now stated rather than left to be discovered.

## Notes for the reviewer

**This is a breaking change.** An invocation that exits 0 today will exit 71 after this. It only breaks invocations that were silently checking less than they asked for, which is the point, but it belongs in the release notes alongside #71.

`71` is a slight stretch — a repeated flag is a malformed command line, nearer to `103`'s territory than to a bad value. It was chosen deliberately over `103`; the wording change above is what makes it honest.

The alternative considered and rejected was making every assertion flag collecting, so repetition accumulates uniformly. That is less code, but it turns `--assert-status 200 --assert-status 201` into something that always fails rather than something that is refused, and it changes what a repeated flag *means* rather than refusing to guess.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)