### PR TITLE
Add -L to follow redirects, and document the default of not following

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,28 @@ http-assert [flags] <URL>
 
 The three header flags can be repeated to make several assertions of that kind. Every other assertion flag takes a single value; giving one twice exits `71` rather than silently keeping the last.
 
+### Redirects
+
+Redirects are not followed. A 3xx is delivered to the assertions exactly as it
+arrived, which is what makes `--assert-redirect` and `--assert-redirect-eq`
+possible at all -- a followed redirect has no `Location` header left to assert
+on.
+
+Callers arriving from `curl` should note that this is the opposite default.
+Combined with `--assert-ok` treating a 3xx as success, a redirecting endpoint
+passes a health check without the resource behind the redirect ever being
+fetched:
+
+```console
+$ http-assert --assert-ok https://old-domain.com/health
+[.] HTTP/1.1 GET https://old-domain.com/health
+[:] HTTP/1.1 301 Moved Permanently
+[+] PASSED 84ms
+```
+
+Assert the status you actually mean (`--assert-status 200`) when that is not
+what you wanted.
+
 ### Logging Options
 
 | Flag | Short | Description |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ http-assert [flags] <URL>
 | `--max-time` | `-m` | Request timeout in seconds (default: 20) |
 | `--insecure` | `-k` | Skip SSL certificate verification |
 | `--maphost` | | Map hostname:port to different destination |
+| `--location` | `-L` | Follow redirects (see [Redirects](#redirects)) |
+| `--max-redirs` | | Maximum redirects to follow with `-L` (default: 10) |
 
 ### Assertion Options
 
@@ -88,10 +90,10 @@ The three header flags can be repeated to make several assertions of that kind. 
 
 ### Redirects
 
-Redirects are not followed. A 3xx is delivered to the assertions exactly as it
-arrived, which is what makes `--assert-redirect` and `--assert-redirect-eq`
-possible at all -- a followed redirect has no `Location` header left to assert
-on.
+Redirects are not followed by default. A 3xx is delivered to the assertions
+exactly as it arrived, which is what makes `--assert-redirect` and
+`--assert-redirect-eq` possible at all -- a followed redirect has no `Location`
+header left to assert on.
 
 Callers arriving from `curl` should note that this is the opposite default.
 Combined with `--assert-ok` treating a 3xx as success, a redirecting endpoint
@@ -107,6 +109,36 @@ $ http-assert --assert-ok https://old-domain.com/health
 
 Assert the status you actually mean (`--assert-status 200`) when that is not
 what you wanted.
+
+`-L` follows the chain instead, and every assertion then applies to the
+response at the end of it:
+
+```console
+$ http-assert -L --assert-status 200 https://old-domain.com/health
+[.] HTTP/1.1 GET https://old-domain.com/health
+[>] 1 GET https://new-domain.com/health
+[:] HTTP/1.1 200 OK
+[+] PASSED 121ms
+```
+
+`--max-redirs` bounds the chain and defaults to 10. `--max-redirs 0` refuses
+every redirect, as in `curl`. Exceeding the bound exits `93` and says so
+explicitly, rather than reporting a network failure that did not happen. The
+option needs `-L` to mean anything, so passing it alone exits `71` rather than
+being quietly ignored.
+
+`-L` cannot be combined with `--assert-redirect` or `--assert-redirect-eq`
+(exit `71`). Following the redirect consumes the 3xx those two exist to
+inspect, so the combination has no reading in which both flags get what they
+asked for.
+
+Two notes on following:
+
+- A `302` on a `POST` is rewritten to a `GET` with no body, per the HTTP
+  specification. Use `307` or `308` to preserve the method and body.
+- `Authorization` and `Cookie` headers set with `-H` are dropped when a hop
+  leaves the original domain. Redirects after the first are chosen by the
+  server, which is why following is opt-in.
 
 ### Logging Options
 
@@ -216,6 +248,15 @@ http-assert \
 http-assert \
   --assert-redirect-eq "https://example.com/target" \
   "https://example.com/redirect?url=https://example.com/target"
+
+# Follow the chain instead, and assert on where it lands
+http-assert -L \
+  --assert-status 200 \
+  --assert-body '"status":\s*"ok"' \
+  https://old-domain.com/health
+
+# Cap the chain; exceeding the cap fails the run
+http-assert -L --max-redirs 2 --assert-ok https://old-domain.com/health
 ```
 
 ### Body Content Validation

--- a/e2e_config_test.go
+++ b/e2e_config_test.go
@@ -15,7 +15,7 @@ import (
 // the two sources is covered separately by TestE2EConfigPrecedence.
 //
 // EnvSupported records what the tool does *today*, not what it should do. Only
-// 6 of the 19 options honour the environment; the other 13 silently ignore it
+// 6 of the 21 options honour the environment; the other 15 silently ignore it
 // (#54 proposes making this uniform). When that lands, flip those booleans --
 // the diff is the proof the change did what it claimed.
 
@@ -123,6 +123,23 @@ func configCases(t *testing.T) []configCase {
 			Base:    []string{"--assert-body-eq", "never-matches", url("/echo")},
 			Applied: func(r result) bool { return strings.Contains(r.Output(), "probe-payload") },
 		},
+		{
+			Flag: "location", CLI: []string{"-L"},
+			EnvKey: "HTTP_ASSERT_LOCATION", EnvVal: "true", EnvSupported: false, Issue: 54,
+			// The 302 carries no body, so only a followed chain can satisfy this.
+			Base:    []string{"--assert-body-eq", "arrived", url("/hop?n=1")},
+			Applied: func(r result) bool { return r.ExitCode == exitOK },
+		},
+		{
+			Flag: "max-redirs", CLI: []string{"--max-redirs", "1"},
+			EnvKey: "HTTP_ASSERT_MAX_REDIRS", EnvVal: "1", EnvSupported: false, Issue: 54,
+			// Three hops: within the default of 10, outside a bound of 1. The
+			// option needs -L to be accepted at all, so -L lives in Base.
+			Base: []string{"-L", "--assert-ok", url("/hop?n=3")},
+			Applied: func(r result) bool {
+				return strings.Contains(r.Output(), "redirect chain was not followed")
+			},
+		},
 
 		// ---- assertion options: all cobra-only ----
 		assertion("assert-ok", []string{"--assert-ok"}, "HTTP_ASSERT_ASSERT_OK", okURL),
@@ -142,7 +159,7 @@ func TestE2EConfigContract(t *testing.T) {
 	cases := configCases(t)
 
 	// Guards against an option being added to the CLI and quietly skipped here.
-	if got, want := len(cases), 19; got != want {
+	if got, want := len(cases), 21; got != want {
 		t.Fatalf("config matrix covers %d options, want %d -- add the new flag to configCases", got, want)
 	}
 
@@ -165,7 +182,7 @@ func TestE2EConfigContract(t *testing.T) {
 			t.Run("env", func(t *testing.T) {
 				if !tc.EnvSupported {
 					characterizes(t, tc.Issue,
-						tc.EnvKey+" is ignored; only 6 of 19 options read the environment")
+						tc.EnvKey+" is ignored; only 6 of 21 options read the environment")
 				}
 				r := run(t, map[string]string{tc.EnvKey: tc.EnvVal}, tc.Base...)
 				if got := tc.Applied(r); got != tc.EnvSupported {

--- a/e2e_redirect_test.go
+++ b/e2e_redirect_test.go
@@ -1,0 +1,176 @@
+package main_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// --location is the only option that changes which response the assertions run
+// against, so what it does is worth pinning precisely: the default it departs
+// from, the boundary of the hop limit it introduces, and the two combinations
+// it refuses.
+//
+// Every test here stays on the loopback test server. /redirect points at a real
+// external host and must never appear with -L (see e2e_server_test.go).
+
+// TestE2ERedirectDefaultIsNotToFollow pins the behaviour --location opts out
+// of. Without it a 3xx is the response, which is what --assert-redirect* reads.
+func TestE2ERedirectDefaultIsNotToFollow(t *testing.T) {
+	t.Run("the 3xx is the response", func(t *testing.T) {
+		assertExit(t, run(t, nil, "--assert-status", "302", url("/hop?n=1")), exitOK)
+	})
+
+	t.Run("the destination is never fetched", func(t *testing.T) {
+		r := run(t, nil, "--assert-body-eq", "arrived", url("/hop?n=1"))
+		assertExit(t, r, exitRequestFail)
+	})
+}
+
+func TestE2ERedirectFollowing(t *testing.T) {
+	t.Run("-L reaches the destination", func(t *testing.T) {
+		assertExit(t, run(t, nil, "-L", "--assert-body-eq", "arrived", url("/hop?n=3")), exitOK)
+	})
+
+	// The point of the feature: --assert-status and --assert-body describe the
+	// far end of the chain, not the 3xx that started it.
+	t.Run("every assertion applies to the final response", func(t *testing.T) {
+		r := run(t, nil, "-L",
+			"--assert-status", "200",
+			"--assert-body", `"status":"success"`,
+			"--assert-header-eq", "X-Api-Version: v1",
+			url("/redirect-local"))
+		assertExit(t, r, exitOK)
+	})
+
+	// The hops are the one part of the run that leaves no trace in the final
+	// response, so they are logged.
+	t.Run("each hop is logged", func(t *testing.T) {
+		r := run(t, nil, "-L", "--assert-ok", url("/hop?n=2"))
+		assertExit(t, r, exitOK)
+		assertContains(t, r, "[>] 1 GET")
+		assertContains(t, r, "[>] 2 GET")
+	})
+
+	// A 302 rewrites POST to GET and drops the body; 308 does not. The body can
+	// only be replayed because http.NewRequest sets GetBody for a strings.Reader.
+	t.Run("308 replays the method and body", func(t *testing.T) {
+		// One pattern rather than two flags: the echo must show both the
+		// method and the body, and a passing run prints neither.
+		r := run(t, nil, "-L", "-X", "POST", "-d", "replayed-payload",
+			"--assert-body", `"body":"replayed-payload".*"method":"POST"`,
+			url("/redirect-308"))
+		assertExit(t, r, exitOK)
+	})
+
+	// Redirects are resolved before the transport dials, so a mapping covers
+	// every hop rather than only the first.
+	t.Run("--maphost applies to every hop", func(t *testing.T) {
+		r := run(t, nil, "--maphost", "mapped.invalid:80="+hostPort(),
+			"-L", "--assert-body-eq", "arrived", "http://mapped.invalid/hop?n=2")
+		assertExit(t, r, exitOK)
+	})
+}
+
+// TestE2ERedirectHopLimit covers the boundary. net/http's own default policy is
+// off by one against its message ("stopped after 10 redirects" follows nine),
+// so --max-redirs N following exactly N hops is worth asserting from both sides.
+func TestE2ERedirectHopLimit(t *testing.T) {
+	t.Run("exactly N hops is allowed", func(t *testing.T) {
+		assertExit(t, run(t, nil, "-L", "--max-redirs", "3",
+			"--assert-body-eq", "arrived", url("/hop?n=3")), exitOK)
+	})
+
+	t.Run("N+1 hops is refused", func(t *testing.T) {
+		r := run(t, nil, "-L", "--max-redirs", "2", "--assert-ok", url("/hop?n=3"))
+		assertExit(t, r, exitRequestFail)
+		// Reported as this program stopping the chain, not as the network
+		// failing -- the reader would otherwise go looking for a broken host.
+		assertContains(t, r, "redirect chain was not followed to the end")
+		assertContains(t, r, "--max-redirs is 2")
+		assertNotContains(t, r, "failed to send request")
+	})
+
+	// curl's meaning for zero, and the reason the comparison is > rather than
+	// the >= net/http uses: zero has to refuse the first hop, not permit it.
+	t.Run("zero refuses every redirect", func(t *testing.T) {
+		r := run(t, nil, "-L", "--max-redirs", "0", "--assert-ok", url("/hop?n=1"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "redirect chain was not followed to the end")
+	})
+
+	t.Run("the default of 10 applies when unset", func(t *testing.T) {
+		assertExit(t, run(t, nil, "-L", "--assert-body-eq", "arrived", url("/hop?n=10")), exitOK)
+
+		r := run(t, nil, "-L", "--assert-ok", url("/hop?n=11"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "--max-redirs is 10")
+	})
+
+	// Nothing else terminates this one.
+	t.Run("a redirect loop ends at the limit", func(t *testing.T) {
+		r := run(t, nil, "-L", "--assert-ok", url("/redirect-loop"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "redirect chain was not followed to the end")
+	})
+}
+
+// TestE2ERedirectRejectedCombinations covers the requests the CLI refuses to
+// serve rather than resolve silently. Each would otherwise produce a green run
+// that checked something other than what was asked for.
+func TestE2ERedirectRejectedCombinations(t *testing.T) {
+	for _, tc := range []struct {
+		Name string
+		Args []string
+		Diag string
+	}{
+		{
+			Name: "-L with --assert-redirect",
+			Args: []string{"-L", "--assert-redirect", ".*", url("/ok")},
+			Diag: "Flags --location and --assert-redirect cannot be used together",
+		},
+		{
+			Name: "-L with --assert-redirect-eq",
+			Args: []string{"-L", "--assert-redirect-eq", "/ok", url("/ok")},
+			Diag: "Flags --location and --assert-redirect-eq cannot be used together",
+		},
+		{
+			Name: "--max-redirs without -L",
+			Args: []string{"--max-redirs", "5", "--assert-ok", url("/ok")},
+			Diag: "bounds a redirect chain that is not being followed",
+		},
+		{
+			Name: "a negative --max-redirs",
+			Args: []string{"-L", "--max-redirs=-1", "--assert-ok", url("/ok")},
+			Diag: "Invalid value for --max-redirs flag: -1",
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			r := run(t, nil, tc.Args...)
+			assertExit(t, r, exitBadFlagVal)
+			assertContains(t, r, tc.Diag)
+		})
+	}
+
+	// The two assertions keep working on their own; the exclusion is about the
+	// combination, not about deprecating them.
+	t.Run("--assert-redirect alone is unaffected", func(t *testing.T) {
+		assertExit(t, run(t, nil, "--assert-redirect", "/ok", url("/redirect-local")), exitOK)
+	})
+}
+
+// TestE2ERedirectFailureDumpNamesTheDestination: after a chain the dumped
+// request is the one that started it, and the response came from somewhere
+// else. Without the extra line the two read as a single exchange.
+func TestE2ERedirectFailureDumpNamesTheDestination(t *testing.T) {
+	r := run(t, nil, "-L", "--assert-status", "999", url("/redirect-local"))
+	assertExit(t, r, exitRequestFail)
+
+	assertContains(t, r, "FAILED: GET "+url("/redirect-local"))
+	assertContains(t, r, "Followed to: GET "+url("/ok"))
+
+	// And it stays out of the way when nothing was followed.
+	plain := run(t, nil, "--assert-status", "999", url("/ok"))
+	if strings.Contains(plain.Output(), "Followed to:") {
+		t.Fatalf("the redirect line appears without a redirect\n%s", plain.Output())
+	}
+}

--- a/e2e_server_test.go
+++ b/e2e_server_test.go
@@ -82,6 +82,40 @@ func testHandler() http.Handler {
 		write(w, http.StatusMovedPermanently, nil, http.Header{"Location": {"/target"}})
 	})
 
+	// The endpoints below exist for --location. Note that /redirect above
+	// points at a real external host, so it must never be used with -L: the
+	// suite would leave the loopback interface and reach the internet.
+
+	// A redirect chain of a chosen length: /hop?n=3 -> /hop?n=2 -> ... ->
+	// /hop?n=0, which is the destination.
+	mux.HandleFunc("/hop", func(w http.ResponseWriter, r *http.Request) {
+		n, err := strconv.Atoi(r.URL.Query().Get("n"))
+		if err != nil || n <= 0 {
+			write(w, http.StatusOK, []byte("arrived"), nil)
+			return
+		}
+		write(w, http.StatusFound, nil, http.Header{
+			"Location": {fmt.Sprintf("/hop?n=%d", n-1)},
+		})
+	})
+
+	// Redirects to itself forever. Only the hop limit can end it, which is what
+	// makes it a test of the limit rather than of patience.
+	mux.HandleFunc("/redirect-loop", func(w http.ResponseWriter, _ *http.Request) {
+		write(w, http.StatusFound, nil, http.Header{"Location": {"/redirect-loop"}})
+	})
+
+	// One hop onto /ok, so the assertions that already match that payload can
+	// be pointed at the far side of a redirect.
+	mux.HandleFunc("/redirect-local", func(w http.ResponseWriter, _ *http.Request) {
+		write(w, http.StatusFound, nil, http.Header{"Location": {"/ok"}})
+	})
+
+	// 308 preserves the method and body across the hop; the 302 above does not.
+	mux.HandleFunc("/redirect-308", func(w http.ResponseWriter, _ *http.Request) {
+		write(w, http.StatusPermanentRedirect, nil, http.Header{"Location": {"/echo"}})
+	})
+
 	// Two values under one header name, for the multi-value matching path.
 	mux.HandleFunc("/multi", func(w http.ResponseWriter, _ *http.Request) {
 		write(w, http.StatusOK, []byte("ok"), http.Header{"Set-Cookie": {"a=1", "b=2"}})

--- a/main.go
+++ b/main.go
@@ -42,9 +42,14 @@
 //
 // # Redirects
 //
-// Redirects are not followed. A 3xx reaches the assertions as it stands, which
-// is the only reason --assert-redirect and --assert-redirect-eq can work: a
-// followed redirect leaves no Location header behind to assert on.
+// Redirects are not followed by default. A 3xx reaches the assertions as it
+// stands, which is the only reason --assert-redirect and --assert-redirect-eq
+// can work: a followed redirect leaves no Location header behind to assert on.
+//
+// --location follows the chain instead, and every assertion then applies to the
+// response at the end of it. --max-redirs bounds the chain. Because following
+// consumes the 3xx, --location and the two redirect assertions are mutually
+// exclusive rather than merely unusual together.
 package main
 
 import (
@@ -108,12 +113,18 @@ Environment:
   There is no flag for them.
 
 Redirects:
-  A 3xx response is asserted on as it stands; the redirect is not followed.
-  That is what --assert-redirect and --assert-redirect-eq assert against.
+  By default a 3xx response is asserted on as it stands and the redirect is
+  not followed. That is what --assert-redirect and --assert-redirect-eq
+  assert against.
 
   This is the opposite of curl's default, and --assert-ok counts a 3xx as
   success, so a redirecting endpoint passes a health check without the
-  resource behind it ever being fetched.`,
+  resource behind it ever being fetched.
+
+  -L follows the chain, and every assertion then applies to the response at
+  the end of it. --max-redirs bounds the chain and needs -L to mean anything.
+  -L cannot be combined with --assert-redirect or --assert-redirect-eq: the
+  3xx those inspect is the very thing -L consumes.`,
 		Example: `  # A health check: any non-error status passes
   http-assert --assert-ok https://example.com/health
 
@@ -121,18 +132,25 @@ Redirects:
   http-assert --assert-status 201 --assert-body '"id":\s*[0-9]+' https://example.com/things
 
   # Send a request to a specific backend, as curl --resolve does
-  http-assert --maphost 'example.com:443=127.0.0.1:8443' --assert-ok https://example.com/`,
+  http-assert --maphost 'example.com:443=127.0.0.1:8443' --assert-ok https://example.com/
+
+  # Follow the redirect chain and assert on where it lands
+  http-assert -L --assert-status 200 https://example.com/old`,
 		Version: versionString(),
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			insecure, _ := cmd.Flags().GetBool("insecure")
 			maxTime, _ := cmd.Flags().GetInt("max-time")
 			maphost, _ := cmd.Flags().GetStringArray("maphost")
+			location, _ := cmd.Flags().GetBool("location")
+			maxRedirs, _ := cmd.Flags().GetInt("max-redirs")
 			c := Client{
-				LogLevel:      mustParseLogLevel(cmd),
-				SkipSslChecks: insecure,
-				Timeout:       time.Duration(maxTime) * time.Second,
-				HostMappings:  mustParseHostMappings(maphost),
+				LogLevel:        mustParseLogLevel(cmd),
+				SkipSslChecks:   insecure,
+				Timeout:         time.Duration(maxTime) * time.Second,
+				HostMappings:    mustParseHostMappings(maphost),
+				FollowRedirects: location,
+				MaxRedirects:    maxRedirs,
 			}
 			c.Init()
 
@@ -175,6 +193,10 @@ Redirects:
 	cmd.Flags().StringArrayP("header", "H", nil, "Set header for HTTP request")
 	cmd.Flags().StringP("data", "d", "",
 		"Sends the specified data in a POST request to the HTTP server")
+	cmd.Flags().BoolP("location", "L", false,
+		"Follow redirects; assertions then apply to the end of the chain")
+	cmd.Flags().Int("max-redirs", 10,
+		"Maximum number of redirects to follow; requires --location")
 	registerAssertionFlags(cmd)
 	rejectRepeats(cmd.Flags())
 
@@ -183,6 +205,7 @@ Redirects:
 		// be mistaken for a second occurrence on the command line.
 		checkRepeats(cmd.Flags())
 		applyEnv(cmd.Flags())
+		checkRedirectFlags(cmd.Flags())
 	}
 
 	if err := cmd.ExecuteContext(context.Background()); err != nil {
@@ -226,6 +249,44 @@ func applyEnv(fs *pflag.FlagSet) {
 		if err := f.Value.Set(v); err != nil {
 			dief(71, "Invalid value for %s=%q: %s", key, v, err)
 		}
+	}
+}
+
+// checkRedirectFlags rejects the three ways --location and --max-redirs can be
+// asked for something they cannot deliver.
+//
+// The first is the one worth refusing loudly. --assert-redirect* inspects the
+// 3xx, and --location is the instruction to consume it, so the pair is a
+// contradiction rather than a combination. Resolving it silently either way
+// leaves a run reporting success for a check it never made.
+//
+// The other two are smaller versions of the same thing: a --max-redirs nobody
+// will read because nothing is being followed, and a negative bound that would
+// refuse the redirect it was meant to permit. Zero is allowed and means what it
+// means in curl -- follow none.
+func checkRedirectFlags(fs *pflag.FlagSet) {
+	follow, _ := fs.GetBool("location")
+
+	if follow {
+		for _, name := range []string{"assert-redirect", "assert-redirect-eq"} {
+			if fs.Changed(name) {
+				dief(71, "Flags --location and --%s cannot be used together: "+
+					"--location follows the redirect, which consumes the 3xx "+
+					"response --%s inspects", name, name)
+			}
+		}
+	}
+
+	if !fs.Changed("max-redirs") {
+		return
+	}
+	if !follow {
+		dief(71, "Flag --max-redirs bounds a redirect chain that is not being "+
+			"followed; pass --location, or drop --max-redirs")
+	}
+	if n, _ := fs.GetInt("max-redirs"); n < 0 {
+		dief(71, "Invalid value for --max-redirs flag: %d; it counts redirects, "+
+			"so the smallest meaningful value is 0", n)
 	}
 }
 
@@ -488,6 +549,12 @@ type Client struct {
 	SkipSslChecks bool
 	Timeout       time.Duration
 	HostMappings  []hostMapping
+	// FollowRedirects turns a 3xx into another request rather than the
+	// response the assertions run against.
+	FollowRedirects bool
+	// MaxRedirects bounds the chain. Zero refuses every redirect; it is only
+	// read when FollowRedirects is set.
+	MaxRedirects int
 }
 
 func (c *Client) Init() {
@@ -500,6 +567,11 @@ func (c *Client) Init() {
 	}
 }
 
+// errTooManyRedirects marks the one transport-shaped failure this program
+// produces itself. Do needs to tell it apart from a network failure, and
+// matching on net/http's message text would be a promise net/http never made.
+var errTooManyRedirects = errors.New("too many redirects")
+
 func (c Client) Do(req *http.Request, assertions ...Assertion) error {
 	if len(assertions) == 0 {
 		return fmt.Errorf("no assertions defined")
@@ -510,10 +582,22 @@ func (c Client) Do(req *http.Request, assertions ...Assertion) error {
 	// G704: the request URL comes from the operator's own command line, and
 	// fetching it is the entire purpose of this tool -- no trust boundary is
 	// crossed, so this is not SSRF.
+	//
+	// --location widens that slightly: the hops after the first are chosen by
+	// the server, not the operator. It stays opt-in for exactly that reason,
+	// and net/http drops Authorization and Cookie when a hop leaves the
+	// original domain, so credentials passed with -H do not travel.
 	res, err := c.getHttpClient().Do(req) // #nosec G704 - user asked for this URL
 	if err != nil {
 		var b strings.Builder
-		fmt.Fprintf(&b, "failed to send request:\n- %s\n", err)
+		// The transport did its job here; this program stopped the chain.
+		// Filing that under "failed to send request" sends the reader looking
+		// for a network problem that does not exist.
+		if errors.Is(err, errTooManyRedirects) {
+			fmt.Fprintf(&b, "redirect chain was not followed to the end:\n- %s\n", err)
+		} else {
+			fmt.Fprintf(&b, "failed to send request:\n- %s\n", err)
+		}
 		c.writeHttpDetails(&b, req, nil)
 		return errors.New(b.String())
 	}
@@ -547,6 +631,13 @@ func (c Client) Do(req *http.Request, assertions ...Assertion) error {
 
 func (c Client) writeHttpDetails(w io.Writer, req *http.Request, res *httpResponse) {
 	_, _ = fmt.Fprintf(w, "\nFAILED: %s %s (%s)\n\n", req.Method, req.URL, req.Proto)
+	// With --location the response below came from somewhere else, and the
+	// request dumped after this is the one that started the chain rather than
+	// the one that produced it. Say so; a reader cannot infer it. The method
+	// is worth printing too, because a 302 rewrites POST to GET.
+	if res != nil && res.Request != nil && res.Request.URL.String() != req.URL.String() {
+		_, _ = fmt.Fprintf(w, "Followed to: %s %s\n\n", res.Request.Method, res.Request.URL)
+	}
 	_ = req.Write(w)
 	_, _ = w.Write([]byte("\n\n"))
 	if res != nil {
@@ -579,7 +670,22 @@ func (c Client) getHttpClient() *http.Client {
 	return &http.Client{
 		Timeout: c.Timeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse // Disallow redirects
+			if !c.FollowRedirects {
+				// The default. Hand the 3xx to the assertions intact --
+				// --assert-redirect* has nothing to look at otherwise.
+				return http.ErrUseLastResponse
+			}
+
+			// via holds the requests already sent, so the k-th redirect sees
+			// len(via) == k. net/http's own default writes >= here and so
+			// follows one fewer hop than its message claims; > is what makes
+			// --max-redirs N mean N, and --max-redirs 0 mean none.
+			if len(via) > c.MaxRedirects {
+				return fmt.Errorf("%w: --max-redirs is %d", errTooManyRedirects, c.MaxRedirects)
+			}
+
+			c.logInfo("[>] %d %s %s", len(via), req.Method, req.URL)
+			return nil
 		},
 		Transport: tr,
 	}

--- a/main.go
+++ b/main.go
@@ -39,6 +39,12 @@
 // The remaining options are command-line only. Repeatable options split one
 // variable on whitespace, which suits host mappings and would corrupt header
 // values.
+//
+// # Redirects
+//
+// Redirects are not followed. A 3xx reaches the assertions as it stands, which
+// is the only reason --assert-redirect and --assert-redirect-eq can work: a
+// followed redirect leaves no Location header behind to assert on.
 package main
 
 import (
@@ -99,7 +105,15 @@ Environment:
   rather than quietly replaced by a zero.
 
   HTTP_PROXY, HTTPS_PROXY and NO_PROXY are honoured for the request itself.
-  There is no flag for them.`,
+  There is no flag for them.
+
+Redirects:
+  A 3xx response is asserted on as it stands; the redirect is not followed.
+  That is what --assert-redirect and --assert-redirect-eq assert against.
+
+  This is the opposite of curl's default, and --assert-ok counts a 3xx as
+  success, so a redirecting endpoint passes a health check without the
+  resource behind it ever being fetched.`,
 		Example: `  # A health check: any non-error status passes
   http-assert --assert-ok https://example.com/health
 
@@ -321,9 +335,9 @@ func registerAssertionFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("assert-ok", false,
 		"Assert response status is not an error (2xx or 3xx)")
 	cmd.Flags().String("assert-redirect", "",
-		"Assert redirect location matches the provided regexp")
+		"Assert redirect location matches the provided regexp; redirects are not followed")
 	cmd.Flags().String("assert-redirect-eq", "",
-		"Assert redirect location equals the provided URL")
+		"Assert redirect location equals the provided URL; redirects are not followed")
 }
 
 // singleValue wraps a flag that holds one value, counting how many times the


### PR DESCRIPTION
## Problem

Checking where a redirect leads takes one `http-assert` run per hop, and nothing in the tool tells you redirects aren't followed.

The second half is the expensive one. `CheckRedirect` has always returned `http.ErrUseLastResponse`, which is the right default for an assertion tool — but neither `--help` nor the README said so. Callers arriving from `curl` assume the opposite, and `--assert-ok` counts a 3xx as success, so a redirecting endpoint passes a health check while the resource behind it is never fetched:

```console
$ http-assert --assert-ok https://old-domain.com/health
[.] HTTP/1.1 GET https://old-domain.com/health
[:] HTTP/1.1 301 Moved Permanently
[+] PASSED 84ms
```

That run is green and checked nothing.

## Solution

Add `-L/--location` to follow the chain and `--max-redirs` to bound it, leaving no-follow as the default.

```console
$ http-assert -L --assert-status 200 http://github.com
[.] HTTP/1.1 GET http://github.com
[>] 1 GET https://github.com/
[:] HTTP/1.1 200 OK
[+] PASSED 653ms
```

Every assertion then applies to the response at the end of the chain. Hops are logged, because they are the one part of the run that leaves no trace in the final response.

### Why the hop comparison is `>` and not `>=`

`net/http`'s own `defaultCheckRedirect` writes `len(via) >= 10` and reports "stopped after 10 redirects" — but `via` holds the requests already sent, so the k-th redirect sees `len(via) == k`, and `>=` therefore follows nine. Copying that idiom would have made `--max-redirs N` mean N−1 and `--max-redirs 0` permit one hop. `>` is what makes the flag mean what it says, and what matches `curl`, where 0 refuses every redirect. Asserted from both sides: exactly N hops passes, N+1 fails.

### Three combinations are refused rather than resolved

| Invocation | Outcome | Why not the alternative |
|---|---|---|
| `-L --assert-redirect…` | exit 71 | Following consumes the 3xx those flags inspect. Whichever side won silently, the run would report success for a check it never made — the failure mode of #35. |
| `--max-redirs` without `-L` | exit 71 | A deliberate divergence from `curl`, which ignores it. A bound on a chain that isn't being followed is a flag that silently does nothing. |
| `--max-redirs=-1` | exit 71 | It counts redirects; 0 is the smallest value with a meaning. |

### Two things follow from the response no longer coming from the URL that was typed

Exceeding the bound is reported as this program stopping the chain, not as a transport failure — `net/http` returns the limit error wrapped in a `url.Error`, which the existing code would have filed under `failed to send request` and sent the reader looking for a broken host. Matched with a sentinel and `errors.Is` rather than on `net/http`'s message text, which is not a promise it ever made.

The failure dump also names the destination, because the request it dumps is the one that *started* the chain while the response came from elsewhere — without the line the two read as a single exchange:

```
FAILED: GET http://example.com/old (HTTP/1.1)

Followed to: GET http://example.com/new
```

The method is printed too, since a 302 rewrites POST to GET.

### Scope

The first commit is documentation only and stands alone: it describes the existing default and lands whether or not the feature does. Both flags are command-line only, consistent with the other thirteen non-`--assert` options, so #54 is extended rather than resolved.

No new dependencies; `go.mod` is untouched.

## Other Changes

Four endpoints on the e2e test server for local redirect chains, loops, and a 308. The pre-existing `/redirect` points at a real external host and now carries a comment saying no `-L` test may use it — a suite that ignored that would quietly start reaching the internet.

The config matrix guard moves 19 → 21. New e2e coverage: the hop-limit boundary, `--max-redirs 0`, a redirect loop terminating, 307/308 method-and-body replay, `--maphost` applying to hops past the first, all three refusals, and the failure-dump line appearing only when something was followed.

There are no screenshots because there is no rendered UI; the user-visible surface of this tool is terminal output, shown inline above.

Closes #47
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

