### PR TITLE
Add --retry so a health check can wait for a service to come up

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ http-assert [flags] <URL>
 | `--maphost` | | Map hostname:port to different destination |
 | `--location` | `-L` | Follow redirects (see [Redirects](#redirects)) |
 | `--max-redirs` | | Maximum redirects to follow with `-L` (default: 10) |
+| `--retry` | | Retry a failed attempt this many times (see [Retries](#retries)) |
+| `--retry-delay` | | Delay between attempts (default: 1s) |
+| `--retry-max-time` | | Stop retrying after this long (default: no limit) |
 
 ### Assertion Options
 
@@ -139,6 +142,61 @@ Two notes on following:
 - `Authorization` and `Cookie` headers set with `-H` are dropped when a hop
   leaves the original domain. Redirects after the first are chosen by the
   server, which is why following is opt-in.
+
+### Retries
+
+The request is made once by default. `--retry` re-sends it after a failed
+attempt, waiting `--retry-delay` in between, and stops at the first attempt
+that passes:
+
+```console
+$ http-assert --retry 5 --retry-delay 1s --assert-ok https://api.example.com/health
+[.] HTTP/1.1 GET https://api.example.com/health
+[:] HTTP/1.1 503 Service Unavailable
+[-] FAILED 3ms
+
+[~] retry 1/5 in 1s
+[.] HTTP/1.1 GET https://api.example.com/health
+[:] HTTP/1.1 200 OK
+[+] PASSED 4ms
+```
+
+**Any failure is retried** -- an unreachable host and a wrong answer alike. The
+case this exists for is waiting for a service to come up, and there the response
+usually arrives perfectly well and says the wrong thing, so retrying only
+transport errors would miss the point. `curl` draws the line differently.
+
+**The delay is fixed, not exponential.** `--retry 30 --retry-delay 1s` reads as
+"poll once a second for half a minute", and the worst case can be worked out
+without a calculator. Sub-second values are allowed: `--retry-delay 250ms`.
+
+**`--max-time` bounds each attempt, not the run.** Both are needed, and the
+worst case is `retry x (max-time + retry-delay) + max-time` -- for `--retry 30`
+at the defaults, over ten minutes. `--retry-max-time` bounds the run instead:
+
+```console
+$ http-assert --retry 100 --retry-delay 5s --retry-max-time 30s --assert-ok https://api.example.com/health
+...
+Error: Cannot perform request: gave up after 6 attempts (--retry-max-time is 30s):
+```
+
+The budget is checked before each retry rather than enforced mid-request, as in
+`curl`, so an attempt already in flight can overrun it by up to one
+`--max-time`. `--retry-max-time 0` -- the default -- means no budget, leaving
+`--retry` as the only bound.
+
+The failure names how many attempts were made. A log showing one failure and no
+sign of the other five reads as a service that was never up, rather than one
+that never came up.
+
+Two combinations are refused with exit `71` rather than quietly ignored:
+`--retry-delay` or `--retry-max-time` without `--retry` (a value nobody will
+read), and a negative value for any of the three -- `pflag` accepts
+`--retry-delay=-2s` without complaint, and it would turn the pause between
+attempts into no pause at all. `--retry 0` is legal and means "make the request
+once", so `--retry ${RETRIES:-0} --retry-delay 1s` works.
+
+Note that the durations take a unit: `--retry-delay 5` is rejected, `5s` is not.
 
 ### Logging Options
 
@@ -259,6 +317,21 @@ http-assert -L \
 http-assert -L --max-redirs 2 --assert-ok https://old-domain.com/health
 ```
 
+### Waiting for a Service to Become Healthy
+
+```bash
+# Poll once a second for half a minute, passing as soon as it answers
+http-assert --retry 30 --retry-delay 1s --assert-ok https://api.example.com/health
+
+# Bound the wait by the clock rather than by the number of attempts
+http-assert --retry 100 --retry-delay 2s --retry-max-time 1m \
+  --assert-status 200 https://api.example.com/health
+
+# Poll a local service quickly; each attempt gets 2s, the run gets 10s
+http-assert --max-time 2 --retry 50 --retry-delay 200ms --retry-max-time 10s \
+  --assert-ok http://localhost:8080/healthz
+```
+
 ### Body Content Validation
 
 ```bash
@@ -299,7 +372,7 @@ export HTTP_ASSERT_INSECURE=true
 http-assert --assert-ok https://api.example.com
 ```
 
-**Every option not in that table is command-line only.** `--request`, `--header`, `--data`, `--location`, `--max-redirs` and every `--assert-*` flag ignore the environment; setting `HTTP_ASSERT_REQUEST=POST` has no effect.
+**Every option not in that table is command-line only.** `--request`, `--header`, `--data`, `--location`, `--max-redirs`, the three `--retry*` options and every `--assert-*` flag ignore the environment; setting `HTTP_ASSERT_REQUEST=POST` or `HTTP_ASSERT_RETRY=5` has no effect.
 
 **A command-line flag always wins over the environment**, which in turn wins over the built-in default. An empty variable counts as unset.
 
@@ -347,12 +420,13 @@ Repeating `--maphost` on the command line accumulates as usual.
 # Deploy and validate service
 deploy-service.sh
 
-# Wait for service to be ready
-sleep 10
-
-# Validate deployment
+# Wait for the service to come up, then validate the deployment. Retrying
+# replaces a fixed `sleep`: it returns as soon as the service is ready instead
+# of always waiting for the worst case, and it does not give up early when the
+# worst case is exceeded.
 http-assert \
   --max-time 30 \
+  --retry 30 --retry-delay 1s \
   --assert-ok \
   --assert-header-eq "X-Service-Version: $EXPECTED_VERSION" \
   https://api.example.com/health
@@ -377,7 +451,8 @@ ENDPOINTS=(
 )
 
 for endpoint in "${ENDPOINTS[@]}"; do
-  if http-assert --silent --assert-ok "$endpoint"; then
+  # Two retries so a single blip does not page anyone at 3am.
+  if http-assert --silent --retry 2 --retry-delay 5s --assert-ok "$endpoint"; then
     echo "✓ $endpoint"
   else
     echo "✗ $endpoint"

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ export HTTP_ASSERT_INSECURE=true
 http-assert --assert-ok https://api.example.com
 ```
 
-**The remaining options are command-line only.** `--request`, `--header`, `--data` and every `--assert-*` flag ignore the environment; setting `HTTP_ASSERT_REQUEST=POST` has no effect.
+**Every option not in that table is command-line only.** `--request`, `--header`, `--data`, `--location`, `--max-redirs` and every `--assert-*` flag ignore the environment; setting `HTTP_ASSERT_REQUEST=POST` has no effect.
 
 **A command-line flag always wins over the environment**, which in turn wins over the built-in default. An empty variable counts as unset.
 

--- a/e2e_config_test.go
+++ b/e2e_config_test.go
@@ -15,7 +15,7 @@ import (
 // the two sources is covered separately by TestE2EConfigPrecedence.
 //
 // EnvSupported records what the tool does *today*, not what it should do. Only
-// 6 of the 21 options honour the environment; the other 15 silently ignore it
+// 6 of the 24 options honour the environment; the other 18 silently ignore it
 // (#54 proposes making this uniform). When that lands, flip those booleans --
 // the diff is the proof the change did what it claimed.
 
@@ -141,6 +141,34 @@ func configCases(t *testing.T) []configCase {
 			},
 		},
 
+		{
+			Flag: "retry", CLI: []string{"--retry", "1"},
+			EnvKey: "HTTP_ASSERT_RETRY", EnvVal: "1", EnvSupported: false, Issue: 54,
+			// A permanently failing endpoint, so the run is decided by whether a
+			// second attempt happened at all rather than by what it returned.
+			Base:    []string{"--assert-ok", url("/500")},
+			Applied: func(r result) bool { return strings.Contains(r.Output(), "[~] retry ") },
+		},
+		{
+			Flag: "retry-delay", CLI: []string{"--retry-delay", "50ms"},
+			EnvKey: "HTTP_ASSERT_RETRY_DELAY", EnvVal: "50ms", EnvSupported: false, Issue: 54,
+			// The delay is announced before it is waited out, which is the only
+			// way to observe the value without timing the process. --retry lives
+			// in Base because the option is not accepted without it.
+			Base:    []string{"--retry", "1", "--assert-ok", url("/500")},
+			Applied: func(r result) bool { return strings.Contains(r.Output(), "in 50ms") },
+		},
+		{
+			Flag: "retry-max-time", CLI: []string{"--retry-max-time", "1ms"},
+			EnvKey: "HTTP_ASSERT_RETRY_MAX_TIME", EnvVal: "1ms", EnvSupported: false, Issue: 54,
+			// A budget too small for even one delay, so it always wins over the
+			// count -- and the message names whichever bound ended the run.
+			Base: []string{"--retry", "3", "--retry-delay", "50ms", "--assert-ok", url("/500")},
+			Applied: func(r result) bool {
+				return strings.Contains(r.Output(), "--retry-max-time is 1ms")
+			},
+		},
+
 		// ---- assertion options: all cobra-only ----
 		assertion("assert-ok", []string{"--assert-ok"}, "HTTP_ASSERT_ASSERT_OK", okURL),
 		assertion("assert-status", []string{"--assert-status", "200"}, "HTTP_ASSERT_ASSERT_STATUS", okURL),
@@ -159,7 +187,7 @@ func TestE2EConfigContract(t *testing.T) {
 	cases := configCases(t)
 
 	// Guards against an option being added to the CLI and quietly skipped here.
-	if got, want := len(cases), 21; got != want {
+	if got, want := len(cases), 24; got != want {
 		t.Fatalf("config matrix covers %d options, want %d -- add the new flag to configCases", got, want)
 	}
 
@@ -182,7 +210,7 @@ func TestE2EConfigContract(t *testing.T) {
 			t.Run("env", func(t *testing.T) {
 				if !tc.EnvSupported {
 					characterizes(t, tc.Issue,
-						tc.EnvKey+" is ignored; only 6 of 21 options read the environment")
+						tc.EnvKey+" is ignored; only 6 of 24 options read the environment")
 				}
 				r := run(t, map[string]string{tc.EnvKey: tc.EnvVal}, tc.Base...)
 				if got := tc.Applied(r); got != tc.EnvSupported {

--- a/e2e_retry_test.go
+++ b/e2e_retry_test.go
@@ -1,0 +1,244 @@
+package main_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --retry is the only option that makes the tool wait rather than answer, so
+// what it does is worth pinning precisely: the default it departs from, what
+// counts as a failure worth another attempt, the two bounds on the loop, and
+// the combinations it refuses.
+//
+// Every delay used here is small but never below 50ms: the end-to-end suite
+// runs on Windows in CI, whose timer granularity is coarse enough to make
+// tighter waits arrive early.
+
+// flaky builds a URL for an endpoint that fails the first n requests and then
+// recovers. The id keeps one test's counter away from every other test's, which
+// matters because the counter lives in this process while the attempts are made
+// by a subprocess.
+func flaky(t *testing.T, path string, n int) string {
+	t.Helper()
+	return url(fmt.Sprintf("%s?id=%s&fail=%d", path, t.Name(), n))
+}
+
+// retries counts the lines the CLI logs between attempts, which is the only
+// externally visible record of how many were made.
+func retries(r result) int { return strings.Count(r.Output(), "[~] retry ") }
+
+// TestE2ERetryDefaultIsASingleAttempt pins the behaviour --retry opts out of.
+func TestE2ERetryDefaultIsASingleAttempt(t *testing.T) {
+	// One failure is all it takes, and the endpoint would have recovered on the
+	// very next request. Without --retry there is no next request.
+	r := run(t, nil, "--assert-ok", flaky(t, "/flaky", 1))
+	assertExit(t, r, exitRequestFail)
+	if n := retries(r); n != 0 {
+		t.Fatalf("retried %d times with --retry unset\n%s", n, r.Output())
+	}
+
+	// And the failure reads exactly as it did before retrying existed: no
+	// attempt count, because there was nothing to count.
+	assertNotContains(t, r, "gave up after")
+}
+
+func TestE2ERetryRecovers(t *testing.T) {
+	// The case the feature exists for: the service is not up yet, so the
+	// response arrives perfectly well and says the wrong thing.
+	t.Run("an assertion failure is retried", func(t *testing.T) {
+		r := run(t, nil, "--retry", "3", "--retry-delay", "50ms",
+			"--assert-ok", flaky(t, "/flaky", 2))
+		assertExit(t, r, exitOK)
+		if n := retries(r); n != 2 {
+			t.Fatalf("retried %d times, want 2\n%s", n, r.Output())
+		}
+	})
+
+	// The other half of "any failure": nothing answered at all.
+	t.Run("a transport failure is retried", func(t *testing.T) {
+		r := run(t, nil, "--retry", "3", "--retry-delay", "50ms",
+			"--assert-ok", flaky(t, "/flaky-hangup", 2))
+		assertExit(t, r, exitOK)
+		if n := retries(r); n != 2 {
+			t.Fatalf("retried %d times, want 2\n%s", n, r.Output())
+		}
+	})
+
+	// Retrying stops at the first attempt that passes; it does not run the
+	// budget down for the sake of it.
+	t.Run("a first-attempt success costs no delay", func(t *testing.T) {
+		start := time.Now()
+		r := run(t, nil, "--retry", "5", "--retry-delay", "10s", "--assert-ok", url("/ok"))
+		assertExit(t, r, exitOK)
+		if n := retries(r); n != 0 {
+			t.Fatalf("retried %d times after a passing attempt\n%s", n, r.Output())
+		}
+		if d := time.Since(start); d > 10*time.Second {
+			t.Fatalf("took %s; the delay was waited out despite the pass", d)
+		}
+	})
+
+	// The request is sent again, not merely the URL. http.Client consumes the
+	// body, so an attempt built from the same request twice would POST nothing
+	// the second time -- and the endpoint would answer 200 to it, hiding the
+	// bug behind a passing run.
+	t.Run("the body survives being sent again", func(t *testing.T) {
+		r := run(t, nil, "--retry", "3", "--retry-delay", "50ms",
+			"-X", "POST", "-d", "replayed-payload",
+			"--assert-body", `"body":"replayed-payload".*"method":"POST"`,
+			flaky(t, "/flaky-echo", 2))
+		assertExit(t, r, exitOK)
+		if n := retries(r); n != 2 {
+			t.Fatalf("retried %d times, want 2\n%s", n, r.Output())
+		}
+	})
+}
+
+// TestE2ERetryExhaustion covers the run that never recovers. The count is the
+// part worth reporting: a log showing one failure and no sign of the other five
+// reads as a service that was never up, rather than one that never came up.
+func TestE2ERetryExhaustion(t *testing.T) {
+	r := run(t, nil, "--retry", "2", "--retry-delay", "50ms", "--assert-ok", url("/500"))
+	assertExit(t, r, exitRequestFail)
+
+	// Two retries is three attempts, not two.
+	assertContains(t, r, "gave up after 3 attempts")
+	if n := retries(r); n != 2 {
+		t.Fatalf("retried %d times, want 2\n%s", n, r.Output())
+	}
+
+	// The last failure is still reported in full underneath the summary.
+	assertContains(t, r, "ok: expected OK, got 500")
+
+	t.Run("--retry 0 is the default spelled out", func(t *testing.T) {
+		r := run(t, nil, "--retry", "0", "--assert-ok", url("/500"))
+		assertExit(t, r, exitRequestFail)
+		assertNotContains(t, r, "gave up after")
+		if n := retries(r); n != 0 {
+			t.Fatalf("retried %d times with --retry 0\n%s", n, r.Output())
+		}
+	})
+}
+
+// TestE2ERetryMaxTime covers the second bound. --retry alone can only be
+// bounded by counting, which says nothing about how long the count will take.
+func TestE2ERetryMaxTime(t *testing.T) {
+	t.Run("the budget ends the run before the count does", func(t *testing.T) {
+		start := time.Now()
+		r := run(t, nil, "--retry", "1000", "--retry-delay", "100ms",
+			"--retry-max-time", "1s", "--assert-ok", url("/500"))
+		assertExit(t, r, exitRequestFail)
+
+		// Which bound stopped it is the whole reason the message names one.
+		assertContains(t, r, "--retry-max-time is 1s")
+
+		// Generous on both sides: the point is that 1000 attempts did not
+		// happen, not that exactly ten did.
+		if n := retries(r); n == 0 || n > 100 {
+			t.Fatalf("retried %d times under a 1s budget with a 100ms delay\n%s", n, r.Output())
+		}
+		if d := time.Since(start); d > 30*time.Second {
+			t.Fatalf("took %s; the budget was not applied", d)
+		}
+	})
+
+	// Zero is not "give up immediately". It is curl's meaning: no budget, so
+	// only --retry bounds the loop.
+	t.Run("zero means no budget", func(t *testing.T) {
+		r := run(t, nil, "--retry", "2", "--retry-delay", "50ms",
+			"--retry-max-time", "0", "--assert-ok", url("/500"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "gave up after 3 attempts")
+		assertNotContains(t, r, "--retry-max-time is")
+	})
+
+	// A budget that outlasts the count leaves the count in charge.
+	t.Run("a budget larger than the count is not reported", func(t *testing.T) {
+		r := run(t, nil, "--retry", "1", "--retry-delay", "50ms",
+			"--retry-max-time", "1m", "--assert-ok", url("/500"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "gave up after 2 attempts")
+		assertNotContains(t, r, "--retry-max-time is")
+	})
+}
+
+// TestE2ERetryMaxTimeIsPerAttempt: -m and --retry-max-time bound different
+// things, and reading -m as a bound on the run would make every retry after the
+// first impossible.
+func TestE2ERetryMaxTimeIsPerAttempt(t *testing.T) {
+	// /slow outlasts a 1s budget every time, so each attempt has to time out
+	// on its own clock for the second one to happen at all.
+	r := run(t, nil, "-m", "1", "--retry", "1", "--retry-delay", "50ms",
+		"--assert-ok", url("/slow"))
+	assertExit(t, r, exitRequestFail)
+
+	if n := retries(r); n != 1 {
+		t.Fatalf("retried %d times, want 1 -- -m was read as a bound on the run\n%s",
+			n, r.Output())
+	}
+	assertContains(t, r, "gave up after 2 attempts")
+	assertContains(t, r, "Client.Timeout")
+}
+
+// TestE2ERetryRejectedCombinations covers the invocations the CLI refuses to
+// serve rather than resolve silently, on the same grounds as --max-redirs
+// without -L: an option nobody will read, or a value that inverts its meaning.
+func TestE2ERetryRejectedCombinations(t *testing.T) {
+	for _, tc := range []struct {
+		Name string
+		Args []string
+		Diag string
+	}{
+		{
+			Name: "--retry-delay without --retry",
+			Args: []string{"--retry-delay", "1s", "--assert-ok", url("/ok")},
+			Diag: "Flag --retry-delay configures retrying that is not switched on",
+		},
+		{
+			Name: "--retry-max-time without --retry",
+			Args: []string{"--retry-max-time", "5s", "--assert-ok", url("/ok")},
+			Diag: "Flag --retry-max-time configures retrying that is not switched on",
+		},
+		{
+			Name: "a negative --retry",
+			Args: []string{"--retry=-1", "--assert-ok", url("/ok")},
+			Diag: "Invalid value for --retry flag: -1",
+		},
+		{
+			// pflag accepts a negative duration without complaint, so nothing
+			// but this check stands between it and a retry loop that never waits.
+			Name: "a negative --retry-delay",
+			Args: []string{"--retry", "1", "--retry-delay=-2s", "--assert-ok", url("/ok")},
+			Diag: "Invalid value for --retry-delay flag: -2s",
+		},
+		{
+			Name: "a negative --retry-max-time",
+			Args: []string{"--retry", "1", "--retry-max-time=-2s", "--assert-ok", url("/ok")},
+			Diag: "Invalid value for --retry-max-time flag: -2s",
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			r := run(t, nil, tc.Args...)
+			assertExit(t, r, exitBadFlagVal)
+			assertContains(t, r, tc.Diag)
+		})
+	}
+
+	// --retry 0 is how a script spells "no retries this time", so the durations
+	// stay legal beside it. Refusing the pair would break `--retry ${N:-0}`.
+	t.Run("--retry 0 still accepts the durations", func(t *testing.T) {
+		r := run(t, nil, "--retry", "0", "--retry-delay", "1s",
+			"--retry-max-time", "5s", "--assert-ok", url("/ok"))
+		assertExit(t, r, exitOK)
+	})
+
+	// The durations are Go durations, so a bare number has no unit and is
+	// rejected by the flag parser rather than guessed at.
+	t.Run("a delay without a unit is refused", func(t *testing.T) {
+		r := run(t, nil, "--retry", "1", "--retry-delay", "5", "--assert-ok", url("/ok"))
+		assertExit(t, r, exitUsage)
+		assertContains(t, r, `missing unit in duration "5"`)
+	})
+}

--- a/e2e_server_test.go
+++ b/e2e_server_test.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -116,6 +119,51 @@ func testHandler() http.Handler {
 		write(w, http.StatusPermanentRedirect, nil, http.Header{"Location": {"/echo"}})
 	})
 
+	// The endpoints below exist for --retry: each fails a fixed number of times
+	// and then starts succeeding, which is the shape of a service coming up.
+	//
+	// Every one of them is keyed by an `id` the caller invents, because the
+	// count has to survive across subprocesses and must not be shared between
+	// two tests that happen to run together.
+
+	// /flaky?id=X&fail=N answers 503 to the first N requests carrying id X and
+	// 200 "healthy" from then on. A 503 fails --assert-ok, so this exercises
+	// retrying an assertion rather than a transport error.
+	mux.HandleFunc("/flaky", func(w http.ResponseWriter, r *http.Request) {
+		if hits(r) <= failCount(r) {
+			write(w, http.StatusServiceUnavailable, []byte("starting"), nil)
+			return
+		}
+		write(w, http.StatusOK, []byte("healthy"), nil)
+	})
+
+	// /flaky-echo?id=X&fail=N is /flaky with /echo's payload once it recovers,
+	// so a test can check what the *last* attempt actually sent.
+	mux.HandleFunc("/flaky-echo", func(w http.ResponseWriter, r *http.Request) {
+		if hits(r) <= failCount(r) {
+			write(w, http.StatusServiceUnavailable, []byte("starting"), nil)
+			return
+		}
+		echo(w, r)
+	})
+
+	// /flaky-hangup?id=X&fail=N drops the connection instead of answering, so
+	// the CLI sees a transport error rather than a response it can assert on.
+	mux.HandleFunc("/flaky-hangup", func(w http.ResponseWriter, r *http.Request) {
+		if hits(r) > failCount(r) {
+			write(w, http.StatusOK, []byte("healthy"), nil)
+			return
+		}
+		// Hijacking and closing without writing anything is the only way to
+		// produce a connection failure from inside a handler.
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			write(w, http.StatusInternalServerError, []byte(err.Error()), nil)
+			return
+		}
+		_ = conn.Close()
+	})
+
 	// Two values under one header name, for the multi-value matching path.
 	mux.HandleFunc("/multi", func(w http.ResponseWriter, _ *http.Request) {
 		write(w, http.StatusOK, []byte("ok"), http.Header{"Set-Cookie": {"a=1", "b=2"}})
@@ -178,28 +226,53 @@ func testHandler() http.Handler {
 	})
 
 	// Reflects the request so tests can observe -X, -H and -d taking effect.
-	mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
-		body := make([]byte, 0, 512)
-		if r.Body != nil {
-			buf := make([]byte, 512)
-			for {
-				n, err := r.Body.Read(buf)
-				body = append(body, buf[:n]...)
-				if err != nil {
-					break
-				}
-			}
-		}
-		payload, _ := json.Marshal(map[string]any{
-			"method":  r.Method,
-			"body":    string(body),
-			"headers": r.Header,
-			"host":    r.Host,
-		})
-		write(w, http.StatusOK, payload, http.Header{"Content-Type": {"application/json"}})
-	})
+	mux.HandleFunc("/echo", echo)
 
 	return mux
+}
+
+func echo(w http.ResponseWriter, r *http.Request) {
+	body := make([]byte, 0, 512)
+	if r.Body != nil {
+		buf := make([]byte, 512)
+		for {
+			n, err := r.Body.Read(buf)
+			body = append(body, buf[:n]...)
+			if err != nil {
+				break
+			}
+		}
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"method":  r.Method,
+		"body":    string(body),
+		"headers": r.Header,
+		"host":    r.Host,
+	})
+	write(w, http.StatusOK, payload, http.Header{"Content-Type": {"application/json"}})
+}
+
+// flakyHits counts requests per `id`, so the flaky endpoints can fail a fixed
+// number of times and then recover. Keyed rather than global because the CLI
+// under test is a subprocess -- the counter cannot live in it -- and two tests
+// sharing one counter would each see the other's attempts.
+var flakyHits sync.Map // id -> *atomic.Int64
+
+// hits returns how many requests this one is, counting from 1, for the id in
+// the query string.
+func hits(r *http.Request) int64 {
+	v, _ := flakyHits.LoadOrStore(r.URL.Query().Get("id"), &atomic.Int64{})
+	return v.(*atomic.Int64).Add(1)
+}
+
+// failCount is how many requests the caller asked to have fail before the
+// endpoint recovers. Absent or unparseable means "fail every time".
+func failCount(r *http.Request) int64 {
+	n, err := strconv.ParseInt(r.URL.Query().Get("fail"), 10, 64)
+	if err != nil {
+		return math.MaxInt64
+	}
+	return n
 }
 
 func acceptsGzip(r *http.Request) bool {

--- a/main.go
+++ b/main.go
@@ -50,6 +50,21 @@
 // response at the end of it. --max-redirs bounds the chain. Because following
 // consumes the 3xx, --location and the two redirect assertions are mutually
 // exclusive rather than merely unusual together.
+//
+// # Retries
+//
+// --retry re-sends the request after a failed attempt, waiting --retry-delay
+// between them. A failure is any failure: a transport error, or an assertion
+// that did not hold. Waiting for a service to come up is the case this exists
+// for, and there the response arrives perfectly well and says the wrong thing.
+//
+// The delay is fixed rather than exponential, so --retry 30 --retry-delay 1s
+// reads as "poll once a second for thirty seconds" and the worst case can be
+// worked out without a calculator.
+//
+// --max-time bounds each attempt; --retry-max-time bounds the whole run. The
+// latter is checked before each retry, so an attempt already in flight can
+// overrun it by up to one --max-time.
 package main
 
 import (
@@ -124,9 +139,23 @@ Redirects:
   -L follows the chain, and every assertion then applies to the response at
   the end of it. --max-redirs bounds the chain and needs -L to mean anything.
   -L cannot be combined with --assert-redirect or --assert-redirect-eq: the
-  3xx those inspect is the very thing -L consumes.`,
+  3xx those inspect is the very thing -L consumes.
+
+Retries:
+  --retry re-sends the request after a failed attempt, waiting --retry-delay
+  between them (1s by default, and fixed rather than exponential). A failure is
+  any failure: a transport error, or an assertion that did not hold. Waiting
+  for a service to come up is what this is for, and there the response arrives
+  perfectly well and says the wrong thing.
+
+  -m bounds each attempt, not the run. --retry-max-time bounds the run and is
+  checked before each retry, so an attempt already in flight can overrun it.
+  Both --retry-delay and --retry-max-time need --retry to mean anything.`,
 		Example: `  # A health check: any non-error status passes
   http-assert --assert-ok https://example.com/health
+
+  # Wait for a service to come up, polling once a second for half a minute
+  http-assert --retry 30 --retry-delay 1s --assert-ok https://example.com/health
 
   # Exact status plus a body pattern
   http-assert --assert-status 201 --assert-body '"id":\s*[0-9]+' https://example.com/things
@@ -144,6 +173,9 @@ Redirects:
 			maphost, _ := cmd.Flags().GetStringArray("maphost")
 			location, _ := cmd.Flags().GetBool("location")
 			maxRedirs, _ := cmd.Flags().GetInt("max-redirs")
+			retry, _ := cmd.Flags().GetInt("retry")
+			retryDelay, _ := cmd.Flags().GetDuration("retry-delay")
+			retryMaxTime, _ := cmd.Flags().GetDuration("retry-max-time")
 			c := Client{
 				LogLevel:        mustParseLogLevel(cmd),
 				SkipSslChecks:   insecure,
@@ -151,6 +183,9 @@ Redirects:
 				HostMappings:    mustParseHostMappings(maphost),
 				FollowRedirects: location,
 				MaxRedirects:    maxRedirs,
+				Retries:         retry,
+				RetryDelay:      retryDelay,
+				RetryMaxTime:    retryMaxTime,
 			}
 			c.Init()
 
@@ -197,6 +232,12 @@ Redirects:
 		"Follow redirects; assertions then apply to the end of the chain")
 	cmd.Flags().Int("max-redirs", 10,
 		"Maximum number of redirects to follow; requires --location")
+	cmd.Flags().Int("retry", 0,
+		"Number of times to retry a failed attempt; 0 makes the request once")
+	cmd.Flags().Duration("retry-delay", time.Second,
+		"Fixed delay between attempts, e.g. 1s or 250ms; requires --retry")
+	cmd.Flags().Duration("retry-max-time", 0,
+		"Stop retrying after this long; 0 means only --retry bounds it; requires --retry")
 	registerAssertionFlags(cmd)
 	rejectRepeats(cmd.Flags())
 
@@ -206,6 +247,7 @@ Redirects:
 		checkRepeats(cmd.Flags())
 		applyEnv(cmd.Flags())
 		checkRedirectFlags(cmd.Flags())
+		checkRetryFlags(cmd.Flags())
 	}
 
 	if err := cmd.ExecuteContext(context.Background()); err != nil {
@@ -287,6 +329,38 @@ func checkRedirectFlags(fs *pflag.FlagSet) {
 	if n, _ := fs.GetInt("max-redirs"); n < 0 {
 		dief(71, "Invalid value for --max-redirs flag: %d; it counts redirects, "+
 			"so the smallest meaningful value is 0", n)
+	}
+}
+
+// checkRetryFlags rejects the ways the retry options can be asked for something
+// they cannot deliver, on the same grounds as checkRedirectFlags above.
+//
+// The two durations are inert without --retry, exactly as --max-redirs is inert
+// without --location: a value nobody will read. The negative cases are worse
+// than inert, because pflag accepts a negative duration without complaint --
+// --retry-delay=-2s parses fine and then never waits.
+//
+// The test for the durations is whether --retry was named, not what it was set
+// to. `--retry ${RETRIES:-0} --retry-delay 1s` is an ordinary shape for a
+// script, and refusing it would break a caller who did nothing wrong.
+func checkRetryFlags(fs *pflag.FlagSet) {
+	if n, _ := fs.GetInt("retry"); n < 0 {
+		dief(71, "Invalid value for --retry flag: %d; it counts retries, so the "+
+			"smallest meaningful value is 0", n)
+	}
+
+	for _, name := range []string{"retry-delay", "retry-max-time"} {
+		if !fs.Changed(name) {
+			continue
+		}
+		if !fs.Changed("retry") {
+			dief(71, "Flag --%s configures retrying that is not switched on; "+
+				"pass --retry, or drop --%s", name, name)
+		}
+		if d, _ := fs.GetDuration(name); d < 0 {
+			dief(71, "Invalid value for --%s flag: %s; it is a length of time, "+
+				"so the smallest meaningful value is 0", name, d)
+		}
 	}
 }
 
@@ -555,6 +629,18 @@ type Client struct {
 	// MaxRedirects bounds the chain. Zero refuses every redirect; it is only
 	// read when FollowRedirects is set.
 	MaxRedirects int
+	// Retries is how many further attempts may follow a failed one. Zero makes
+	// the request once, which is the default and the behaviour that predates
+	// retrying.
+	Retries int
+	// RetryDelay is the fixed wait between attempts. Only read when Retries is
+	// positive.
+	RetryDelay time.Duration
+	// RetryMaxTime bounds the whole run, measured from the first attempt. Zero
+	// means only Retries bounds it. It is checked before each retry rather than
+	// enforced mid-flight, so an attempt already under way can overrun it by up
+	// to one Timeout -- which is curl's meaning for the same option.
+	RetryMaxTime time.Duration
 }
 
 func (c *Client) Init() {
@@ -572,10 +658,73 @@ func (c *Client) Init() {
 // matching on net/http's message text would be a promise net/http never made.
 var errTooManyRedirects = errors.New("too many redirects")
 
+// Do makes the request and checks the response against every assertion,
+// retrying a failed attempt up to Retries times.
+//
+// Any failure is retried, an unreachable host and a wrong answer alike. The
+// case retrying exists for is waiting for a service to come up, and there the
+// response usually arrives perfectly well and says the wrong thing, so a rule
+// that retried only transport errors would miss the whole point.
 func (c Client) Do(req *http.Request, assertions ...Assertion) error {
 	if len(assertions) == 0 {
+		// Not a failed attempt but a malformed invocation, so it is reported
+		// once rather than retried into the ground.
 		return fmt.Errorf("no assertions defined")
 	}
+
+	// Built once rather than per attempt: an http.Transport owns an idle
+	// connection pool, and a fresh one per attempt would leave --retry 100 of
+	// them behind for the lifetime of the process.
+	client := c.getHttpClient()
+	startedAt := time.Now()
+
+	for attempt := 1; ; attempt++ {
+		err := c.doOnce(client, req, assertions)
+		if err == nil {
+			return nil
+		}
+
+		switch {
+		case attempt > c.Retries:
+			return c.giveUp(attempt, "", err)
+		// Checked before sleeping rather than after, so the run ends at the
+		// budget instead of one delay past it.
+		case c.RetryMaxTime > 0 && time.Since(startedAt)+c.RetryDelay > c.RetryMaxTime:
+			return c.giveUp(attempt, "--retry-max-time is "+c.RetryMaxTime.String(), err)
+		}
+
+		c.logInfo("[~] retry %d/%d in %s\n", attempt, c.Retries, c.RetryDelay)
+		time.Sleep(c.RetryDelay)
+	}
+}
+
+// giveUp reports the last failure together with how the run ended.
+//
+// Without the prefix a CI log shows a single failed attempt and no sign that
+// five more happened, which reads as a service that was never up rather than
+// one that never came up. Nothing is added when nothing was retried, so a plain
+// run says exactly what it always said.
+func (c Client) giveUp(attempts int, limit string, err error) error {
+	if c.Retries <= 0 {
+		return err
+	}
+
+	if limit != "" {
+		limit = " (" + limit + ")"
+	}
+	return fmt.Errorf("gave up after %d attempts%s:\n%w", attempts, limit, err)
+}
+
+// doOnce performs one request and checks it against every assertion.
+func (c Client) doOnce(client *http.Client, req *http.Request, assertions []Assertion) error {
+	next, err := cloneForAttempt(req)
+	if err != nil {
+		var b strings.Builder
+		fmt.Fprintf(&b, "failed to rewind the request body:\n- %s\n", err)
+		c.writeHttpDetails(&b, req, nil)
+		return errors.New(b.String())
+	}
+	req = next
 
 	c.logInfo("[.] %s %s %s", req.Proto, req.Method, req.URL)
 	startedAt := time.Now()
@@ -587,7 +736,7 @@ func (c Client) Do(req *http.Request, assertions ...Assertion) error {
 	// the server, not the operator. It stays opt-in for exactly that reason,
 	// and net/http drops Authorization and Cookie when a hop leaves the
 	// original domain, so credentials passed with -H do not travel.
-	res, err := c.getHttpClient().Do(req) // #nosec G704 - user asked for this URL
+	res, err := client.Do(req) // #nosec G704 - user asked for this URL
 	if err != nil {
 		var b strings.Builder
 		// The transport did its job here; this program stopped the chain.
@@ -597,6 +746,12 @@ func (c Client) Do(req *http.Request, assertions ...Assertion) error {
 			fmt.Fprintf(&b, "redirect chain was not followed to the end:\n- %s\n", err)
 		} else {
 			fmt.Fprintf(&b, "failed to send request:\n- %s\n", err)
+		}
+		// This path logs nothing between [.] and the dump the caller prints,
+		// which is fine for a single attempt and unreadable for twenty. The
+		// line appears only while retrying so that a plain run is untouched.
+		if c.Retries > 0 {
+			c.logInfo("[-] FAILED %s: %s\n", time.Since(startedAt), err)
 		}
 		c.writeHttpDetails(&b, req, nil)
 		return errors.New(b.String())
@@ -627,6 +782,31 @@ func (c Client) Do(req *http.Request, assertions ...Assertion) error {
 
 	c.logInfo("[+] PASSED %s\n\n", time.Since(startedAt))
 	return nil
+}
+
+// cloneForAttempt returns a request that can be sent even if the one it was
+// built from already has been.
+//
+// http.Client consumes and closes req.Body, so re-sending the same *http.Request
+// carries an empty body unless net/http can replay it through GetBody. Today it
+// can -- the CLI builds the body from a strings.Reader, which is one of the
+// three types http.NewRequest recognises -- but that is a property of the body
+// type rather than a guarantee, and a body without GetBody would silently send
+// nothing on the second attempt. Cloning costs six lines and does not depend on
+// which reader the caller happened to pass.
+func cloneForAttempt(req *http.Request) (*http.Request, error) {
+	res := req.Clone(req.Context())
+	if req.GetBody == nil {
+		return res, nil // no body, or http.NoBody, which re-reads as empty
+	}
+
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	res.Body = body
+
+	return res, nil
 }
 
 func (c Client) writeHttpDetails(w io.Writer, req *http.Request, res *httpResponse) {

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// cloneForAttempt is the piece of retrying that cannot be observed from the
+// outside once it works, and cannot be observed at all once it does not: a
+// second attempt that quietly sends an empty body still gets a response, and
+// the run goes green having posted nothing.
+func Test_cloneForAttempt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Name string
+		Body io.Reader
+		Want string
+	}{
+		{
+			// What the CLI actually builds for -d. http.NewRequest recognises
+			// the type and installs GetBody, which is what makes the replay
+			// possible at all.
+			Name: "a string body is replayed",
+			Body: strings.NewReader("payload"),
+			Want: "payload",
+		},
+		{
+			// What the CLI builds without -d. There is no GetBody here, and
+			// none is needed: http.NoBody re-reads as empty forever.
+			Name: "no body stays no body",
+			Body: http.NoBody,
+			Want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "http://example.com/", tc.Body)
+			if err != nil {
+				t.Fatalf("cannot build the request: %s", err)
+			}
+			req.Header.Set("X-Probe", "1")
+
+			// Twice, because the first attempt is the one that drains the
+			// original. A clone that works only before that is no use.
+			for attempt := 1; attempt <= 2; attempt++ {
+				c, err := cloneForAttempt(req)
+				if err != nil {
+					t.Fatalf("attempt %d: %s", attempt, err)
+				}
+
+				body, err := io.ReadAll(c.Body)
+				if err != nil {
+					t.Fatalf("attempt %d: cannot read the body: %s", attempt, err)
+				}
+				_ = c.Body.Close()
+
+				if got := string(body); got != tc.Want {
+					t.Errorf("attempt %d: body = %q, want %q", attempt, got, tc.Want)
+				}
+				if got, want := c.Method, "POST"; got != want {
+					t.Errorf("attempt %d: method = %q, want %q", attempt, got, want)
+				}
+				if got, want := c.Header.Get("X-Probe"), "1"; got != want {
+					t.Errorf("attempt %d: X-Probe = %q, want %q", attempt, got, want)
+				}
+			}
+		})
+	}
+}
+
+// Test_cloneForAttempt_isolatesHeaders: the clone must not share the header map
+// with the request it came from, or a header added by one attempt would still
+// be there on the next.
+func Test_cloneForAttempt_isolatesHeaders(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequest("GET", "http://example.com/", http.NoBody)
+	if err != nil {
+		t.Fatalf("cannot build the request: %s", err)
+	}
+
+	c, err := cloneForAttempt(req)
+	if err != nil {
+		t.Fatalf("cannot clone: %s", err)
+	}
+	c.Header.Set("X-Added-By-This-Attempt", "1")
+
+	if got := req.Header.Get("X-Added-By-This-Attempt"); got != "" {
+		t.Errorf("the original gained a header from its clone: %q", got)
+	}
+}


### PR DESCRIPTION
## Problem

Waiting for a service to become healthy meant sleeping for a guess, because there was no retry.

The README recommended it in its own CI/CD example — the tool's headline use case, apologising for itself:

```bash
deploy-service.sh
sleep 10
http-assert --max-time 30 --assert-ok https://api.example.com/health
```

A fixed sleep is wrong in both directions. When the service is ready in two seconds, eight are wasted on every pipeline run. When it needs eleven, the check fails and the deploy is rolled back over a service that was fine. Neither failure is visible in the output — the second one looks exactly like a broken deploy.

## Solution

`--retry` polls instead, returning the moment an attempt passes.

```console
$ http-assert --retry 5 --retry-delay 300ms --assert-ok http://127.0.0.1:8080/health
[.] HTTP/1.1 GET http://127.0.0.1:8080/health
[:] HTTP/1.1 503 Service Unavailable
[-] FAILED 1.09ms

[~] retry 1/5 in 300ms
[.] HTTP/1.1 GET http://127.0.0.1:8080/health
[:] HTTP/1.1 503 Service Unavailable
[-] FAILED 264µs

[~] retry 2/5 in 300ms
[.] HTTP/1.1 GET http://127.0.0.1:8080/health
[:] HTTP/1.1 200 OK
[+] PASSED 239µs
```

### Any failure is retried, not just transport errors

The case this exists for is a service that is not up yet, and there the response arrives perfectly well and says the wrong thing. `curl` retries transient statuses and needs `--retry-all-errors` for the rest; here the assertion *is* the health definition, so splitting the rule would need a fourth flag to say "no, really, retry the thing I asked you to check".

The one failure deliberately **not** retried is `no assertions defined` — a malformed invocation, not a failed attempt.

### The delay is fixed, not exponential

`--retry 30 --retry-delay 1s` reads as "poll once a second for half a minute". `curl` defaults to doubling, which makes the total wait for a given count non-obvious — 31 seconds for `--retry 5`, not 5 — and turns `--retry-max-time` from optional into near-mandatory. Sub-second values work: `--retry-delay 250ms`.

### `-m` bounds each attempt; `--retry-max-time` bounds the run

Both are needed. `--retry 30` at the defaults is a worst case of `30 x (20s + 1s) + 20s`, over ten minutes. The budget is checked before each retry rather than enforced mid-request, as in `curl`, so an attempt already in flight can overrun it by up to one `-m`. The message names whichever bound ended the run:

```
Error: Cannot perform request: gave up after 6 attempts (--retry-max-time is 30s):
```

The attempt count matters on its own. A CI log showing one failure and no sign of the other five reads as a service that was never up, rather than one that never came up.

### The request is cloned per attempt, and that is not a nicety

`http.Client` consumes and closes `req.Body`, so re-sending the same `*http.Request` should post nothing the second time. It doesn't — `net/http` rewinds through `req.GetBody` — but only because the CLI builds its body from a `strings.Reader`, one of three types `http.NewRequest` special-cases. Clear `GetBody` on an otherwise identical request and attempt 2 dies:

```
http: ContentLength=7 with Body length 0
```

Hand it an opaque `io.Reader` instead and there is no error at all: attempt 2 sends an empty body, the server answers `200`, and the run goes green having posted nothing. That is the same class of bug as #35 — success reported for a check that was never made — reachable through a body type rather than a flag. Six lines of cloning make it independent of which reader the caller happened to pass, and an e2e test replays a `POST` body across two failed attempts against `/flaky-echo`.

### Three refusals rather than silent resolutions

| Invocation | Outcome | Why not the alternative |
|---|---|---|
| `--retry-delay` / `--retry-max-time` without `--retry` | exit 71 | A bound on a loop that is not running — the `--max-redirs`-without-`-L` argument, unchanged. |
| `--retry=-1` | exit 71 | It counts retries; 0 is the smallest value with a meaning. |
| `--retry-delay=-2s` | exit 71 | `pflag` parses a negative duration without complaint, and it would turn the pause between attempts into no pause at all. |

`--retry 0` stays legal beside both durations, because `--retry ${RETRIES:-0} --retry-delay 1s` is an ordinary shape for a script and refusing it would break a caller who did nothing wrong. The check is `Changed("retry")`, not the value.

### Scope

Both durations are Go durations, so `--retry-delay 5` is rejected for having no unit. That is the cost of expressing `250ms`, which integer seconds cannot.

All three options are command-line only, consistent with the other fifteen non-`--assert` options, so #54 is extended rather than resolved. `--retry-max-time 0` means "no budget", as in `curl`; unlike the `--max-time 0` of #31 it cannot produce an unbounded wait, because `--retry` always bounds the loop.

No new dependencies; `go.mod` is untouched.

## Other Changes

`http.Client` is now built once per run instead of once per attempt. A `Transport` owns an idle connection pool, and `--retry 100` would have left a hundred of them alive until the process exited.

Three endpoints on the e2e server, each keyed by a caller-invented `id` so two tests cannot share a counter: `/flaky` (fails N times, then 200), `/flaky-echo` (same, then reflects the request), and `/flaky-hangup`, which hijacks and closes the connection to produce a genuine transport failure rather than a status code. `/echo`'s handler was lifted to a named function so `/flaky-echo` can reuse it.

The config matrix guard moves 21 → 24. New e2e coverage: recovery from assertion and transport failures, exhaustion reporting the count, the budget cutting a 1000-retry run short, `-m` staying per attempt, body replay, and all five refusals. Every delay in the suite is ≥ 50ms — CI runs e2e on Windows, whose timer granularity would make tighter waits arrive early.

The first commit is unrelated to retrying and stands alone: the README's list of options that ignore the environment named four and stopped, so `--location` and `--max-redirs` have read as environment-backed since #74 landed.

There are no screenshots because there is no rendered UI; this tool's user-visible surface is terminal output, shown inline above.

## Notes for the reviewer

A transport failure logs nothing between `[.]` and the failure dump. That is fine for one attempt and unreadable for twenty, so a compact `[-] FAILED <elapsed>: <err>` line was added — **only while retrying**, so that a plain run stays byte-identical. Making it unconditional would be an improvement and a change to every existing user's output; it did not belong here.

Two design questions the issue asked to settle were decided against `curl`: fixed delay over exponential, and Go durations over integer seconds. Both are reversible before release and neither has shipped in a tag yet.

Related:
- https://github.com/korya/http-assert/pull/74 — `-L`, whose README section this one is modelled on
- https://github.com/korya/http-assert/issues/71 — retry exhaustion still exits `93`, so the unreachable-vs-wrong split is untouched
- https://github.com/korya/http-assert/issues/31 — `--retry-max-time 0` meaning "no limit" is the same shape, with a bound behind it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EMMhgmTkbzAsmeNy97PrP
