### PR TITLE
Decode the response body before assertions run

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ $ http-assert --retry 5 --retry-delay 1s --assert-ok https://api.example.com/hea
 
 **Any failure is retried** -- an unreachable host and a wrong answer alike. The
 case this exists for is waiting for a service to come up, and there the response
-usually arrives perfectly well and says the wrong thing, so retrying only
-transport errors would miss the point. `curl` draws the line differently.
+usually arrives perfectly well and says the wrong thing, so retrying only the
+connection failures would miss the point. `curl` draws the line differently.
 
 **The delay is fixed, not exponential.** `--retry 30 --retry-delay 1s` reads as
 "poll once a second for half a minute", and the worst case can be worked out
@@ -193,10 +193,10 @@ that never came up.
 
 Two combinations are refused with exit `71` rather than quietly ignored:
 `--retry-delay` or `--retry-max-time` without `--retry` (a value nobody will
-read), and a negative value for any of the three -- `pflag` accepts
-`--retry-delay=-2s` without complaint, and it would turn the pause between
-attempts into no pause at all. `--retry 0` is legal and means "make the request
-once", so `--retry ${RETRIES:-0} --retry-delay 1s` works.
+read), and a negative value for any of the three. `--retry-delay=-2s` is a
+well-formed duration but would turn the pause between attempts into no pause at
+all, so it is refused rather than obeyed. `--retry 0` is legal and means "make
+the request once", so `--retry ${RETRIES:-0} --retry-delay 1s` works.
 
 Note that the durations take a unit: `--retry-delay 5` is rejected, `5s` is not.
 
@@ -227,10 +227,10 @@ http-assert \
   https://api.example.com/
 ```
 
-**Nothing is advertised in `Accept-Encoding` unless you ask for it.** `curl` and
-Go's HTTP client both add the header on your behalf; this does not, so a server
-that compresses only on request will answer in plain. Ask with `-H` when you
-want to exercise content negotiation.
+**Nothing is advertised in `Accept-Encoding` unless you ask for it.** `curl`
+sends the header on your behalf; this does not, so a server that compresses only
+on request will answer in plain. Ask with `-H` when you want to exercise content
+negotiation.
 
 **An encoding with no decoder here fails only the body assertions**, naming
 itself, and leaves the rest of the run intact:
@@ -243,10 +243,9 @@ $ http-assert --assert-ok https://cdn.example.com/
 [+] PASSED 38ms
 ```
 
-Brotli and zstd are the encodings this covers in practice. Neither has a
-decoder in the Go standard library, and a health-check tool is not worth a
-dependency for it -- so a status check keeps working while a body assertion
-says plainly that it cannot run.
+Brotli (`br`) and zstd are the encodings this covers in practice. Neither is
+supported yet: [#77](https://github.com/korya/http-assert/issues/77) tracks
+brotli and [#78](https://github.com/korya/http-assert/issues/78) tracks zstd.
 
 A header that claims an encoding the body does not have is treated the same
 way. Reading those bytes as plain text would be its own silent corruption.
@@ -431,7 +430,7 @@ http-assert --assert-ok https://api.example.com
 
 #### Proxies
 
-`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are honoured for the request itself, through Go's standard proxy resolution. There is no flag for them, and no way to disable the behaviour from the command line — if one of these is set in your environment for unrelated reasons, requests go through it.
+`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are honoured for the request itself. There is no flag for them, and no way to disable the behaviour from the command line — if one of these is set in your environment for unrelated reasons, requests go through it.
 
 **A value that does not parse is rejected** rather than ignored, so a typo cannot silently change behaviour:
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ http-assert [flags] <URL>
 
 The three header flags can be repeated to make several assertions of that kind. Every other assertion flag takes a single value; giving one twice exits `71` rather than silently keeping the last.
 
+The three body assertions run against the decoded payload, never the bytes on the wire — see [Compression](#compression).
+
 ### Redirects
 
 Redirects are not followed by default. A 3xx is delivered to the assertions
@@ -197,6 +199,57 @@ attempts into no pause at all. `--retry 0` is legal and means "make the request
 once", so `--retry ${RETRIES:-0} --retry-delay 1s` works.
 
 Note that the durations take a unit: `--retry-delay 5` is rejected, `5s` is not.
+
+### Compression
+
+A compressed body is decoded before the assertions run, so the body assertions
+always see the payload:
+
+```console
+$ http-assert -H 'Accept-Encoding: gzip' --assert-body '"status":"success"' https://api.example.com/
+[.] HTTP/1.1 GET https://api.example.com/
+[:] HTTP/1.1 200 OK
+[+] PASSED 41ms
+```
+
+`gzip` and `deflate` are understood, the latter in both the zlib form the RFC
+specifies and the raw form much of the web actually sends.
+
+**The response headers are reported exactly as they arrived.** Nothing is
+deleted on the way, so a run can assert on the body *and* on how it was
+encoded:
+
+```bash
+http-assert \
+  -H 'Accept-Encoding: gzip' \
+  --assert-header-eq "Content-Encoding: gzip" \
+  --assert-body-eq '{"status":"success"}' \
+  https://api.example.com/
+```
+
+**Nothing is advertised in `Accept-Encoding` unless you ask for it.** `curl` and
+Go's HTTP client both add the header on your behalf; this does not, so a server
+that compresses only on request will answer in plain. Ask with `-H` when you
+want to exercise content negotiation.
+
+**An encoding with no decoder here fails only the body assertions**, naming
+itself, and leaves the rest of the run intact:
+
+```console
+$ http-assert --assert-body '"status":"success"' https://cdn.example.com/
+- body: response is br-encoded and was not decoded: no decoder for "br"; gzip and deflate are supported
+
+$ http-assert --assert-ok https://cdn.example.com/
+[+] PASSED 38ms
+```
+
+Brotli and zstd are the encodings this covers in practice. Neither has a
+decoder in the Go standard library, and a health-check tool is not worth a
+dependency for it -- so a status check keeps working while a body assertion
+says plainly that it cannot run.
+
+A header that claims an encoding the body does not have is treated the same
+way. Reading those bytes as plain text would be its own silent corruption.
 
 ### Logging Options
 

--- a/assertions.go
+++ b/assertions.go
@@ -104,10 +104,31 @@ func AssertHeaderMatch(name, expPattern string) (Assertion, error) {
 	}, nil
 }
 
+// bodyOf returns the payload, or an error saying why there is none to assert
+// against.
+//
+// Every body assertion goes through it. Matching against bytes that are still
+// compressed produced a false failure with an unexplained hex dump -- and, with
+// a loose enough pattern, a false pass, which is the one outcome this program
+// exists to refuse (#27).
+func bodyOf(res *httpResponse) ([]byte, error) {
+	if res.DecodeErr != nil {
+		return nil, fmt.Errorf("body: response is %s-encoded and was not decoded: %s",
+			res.Encoding, res.DecodeErr)
+	}
+
+	return res.BodyBytes, nil
+}
+
 func AssertBodyEmpty() Assertion {
 	return func(res *httpResponse) error {
-		if len(res.BodyBytes) > 0 {
-			return fmt.Errorf("body: expected to be empty, got %q", string(res.BodyBytes))
+		body, err := bodyOf(res)
+		if err != nil {
+			return err
+		}
+
+		if len(body) > 0 {
+			return fmt.Errorf("body: expected to be empty, got %q", string(body))
 		}
 
 		return nil
@@ -116,11 +137,16 @@ func AssertBodyEmpty() Assertion {
 
 func AssertBodyEqual(expContent string) Assertion {
 	return func(res *httpResponse) error {
-		if len(res.BodyBytes) == 0 {
+		body, err := bodyOf(res)
+		if err != nil {
+			return err
+		}
+
+		if len(body) == 0 {
 			return fmt.Errorf("body: expected %q, missing", expContent)
 		}
 
-		if c := string(res.BodyBytes); expContent != c {
+		if c := string(body); expContent != c {
 			return fmt.Errorf("body: expected %q, got %q", expContent, c)
 		}
 
@@ -135,11 +161,16 @@ func AssertBodyMatch(expPattern string) (Assertion, error) {
 	}
 
 	return func(res *httpResponse) error {
-		if len(res.BodyBytes) == 0 {
+		body, err := bodyOf(res)
+		if err != nil {
+			return err
+		}
+
+		if len(body) == 0 {
 			return fmt.Errorf("body: expected to match %q, missing", expPattern)
 		}
 
-		if c := string(res.BodyBytes); !re.MatchString(c) {
+		if c := string(body); !re.MatchString(c) {
 			return fmt.Errorf("body: expected to match %q, got %q", expPattern, c)
 		}
 

--- a/compression_test.go
+++ b/compression_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/zlib"
+	"net/http"
+	"testing"
+)
+
+const payload = `{"status":"success"}`
+
+func gzipped(t *testing.T, s string) []byte {
+	t.Helper()
+
+	var b bytes.Buffer
+	zw := gzip.NewWriter(&b)
+	if _, err := zw.Write([]byte(s)); err != nil {
+		t.Fatalf("cannot gzip: %s", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("cannot close the gzip writer: %s", err)
+	}
+
+	return b.Bytes()
+}
+
+func deflatedRaw(t *testing.T, s string) []byte {
+	t.Helper()
+
+	var b bytes.Buffer
+	zw, err := flate.NewWriter(&b, flate.DefaultCompression)
+	if err != nil {
+		t.Fatalf("cannot build the flate writer: %s", err)
+	}
+	if _, err := zw.Write([]byte(s)); err != nil {
+		t.Fatalf("cannot deflate: %s", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("cannot close the flate writer: %s", err)
+	}
+
+	return b.Bytes()
+}
+
+func deflatedZlib(t *testing.T, s string) []byte {
+	t.Helper()
+
+	var b bytes.Buffer
+	zw := zlib.NewWriter(&b)
+	if _, err := zw.Write([]byte(s)); err != nil {
+		t.Fatalf("cannot zlib: %s", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("cannot close the zlib writer: %s", err)
+	}
+
+	return b.Bytes()
+}
+
+// encoded builds the shape decodeBody operates on: a body and the header that
+// claims how it was encoded. It reuses render_test.go's response helper so both
+// files describe an httpResponse the same way.
+func encoded(enc string, body []byte) *httpResponse {
+	h := http.Header{}
+	if enc != "" {
+		h.Set("Content-Encoding", enc)
+	}
+
+	r := response("200 OK", h, "")
+	r.BodyBytes = body
+
+	return &r
+}
+
+// Test_decodeBody is the whole of #27 in one table: what the assertions end up
+// reading, for every way a body can arrive.
+func Test_decodeBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Name string
+		Enc  string
+		Body []byte
+		// Want is the payload the assertions should see. Only checked when
+		// WantErr is false.
+		Want string
+		// WantErr means the body could not be decoded, so the body assertions
+		// must refuse rather than match against what is there.
+		WantErr bool
+		// WantEncoding is what Content-Encoding is recorded as, verbatim.
+		WantEncoding string
+	}{
+		{
+			Name: "no encoding at all",
+			Body: []byte(payload),
+			Want: payload,
+		},
+		{
+			Name:         "identity is not an encoding to remove",
+			Enc:          "identity",
+			Body:         []byte(payload),
+			Want:         payload,
+			WantEncoding: "identity",
+		},
+		{
+			Name:         "gzip",
+			Enc:          "gzip",
+			Body:         gzipped(t, payload),
+			Want:         payload,
+			WantEncoding: "gzip",
+		},
+		{
+			// Content coding names are case-insensitive per RFC 9110, and a
+			// case-sensitive lookup would refuse a body it can decode.
+			Name:         "GZIP, in the case the server chose",
+			Enc:          "GZIP",
+			Body:         gzipped(t, payload),
+			Want:         payload,
+			WantEncoding: "GZIP",
+		},
+		{
+			Name:         "gzip with surrounding whitespace",
+			Enc:          " gzip ",
+			Body:         gzipped(t, payload),
+			Want:         payload,
+			WantEncoding: "gzip",
+		},
+		{
+			// The two formats that share the deflate name. Neither reader
+			// accepts the other's input, so trying both is safe.
+			Name:         "deflate, raw",
+			Enc:          "deflate",
+			Body:         deflatedRaw(t, payload),
+			Want:         payload,
+			WantEncoding: "deflate",
+		},
+		{
+			Name:         "deflate, zlib-wrapped",
+			Enc:          "deflate",
+			Body:         deflatedZlib(t, payload),
+			Want:         payload,
+			WantEncoding: "deflate",
+		},
+		{
+			Name:         "an encoding with no decoder here",
+			Enc:          "br",
+			Body:         []byte{0x1b, 0x13, 0x00},
+			WantErr:      true,
+			WantEncoding: "br",
+		},
+		{
+			// The header claims gzip and the bytes are not. Silently asserting
+			// against them is the bug; so is silently treating them as plain.
+			Name:         "a body that does not match its stated encoding",
+			Enc:          "gzip",
+			Body:         []byte(payload),
+			WantErr:      true,
+			WantEncoding: "gzip",
+		},
+		{
+			Name:         "a truncated gzip stream",
+			Enc:          "gzip",
+			Body:         gzipped(t, payload)[:10],
+			WantErr:      true,
+			WantEncoding: "gzip",
+		},
+		{
+			// A 204 that carries the header anyway. There is nothing to decode,
+			// and an empty gzip stream is an error rather than an empty
+			// payload -- so --assert-body-empty must still pass.
+			Name:         "an empty body with an encoding header",
+			Enc:          "gzip",
+			Body:         nil,
+			Want:         "",
+			WantEncoding: "gzip",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := encoded(tc.Enc, tc.Body)
+			res.decodeBody()
+
+			if got, want := res.Encoding, tc.WantEncoding; got != want {
+				t.Errorf("Encoding = %q, want %q", got, want)
+			}
+
+			if tc.WantErr {
+				if res.DecodeErr == nil {
+					t.Fatalf("DecodeErr = nil, want an error; body reads %q", string(res.BodyBytes))
+				}
+				// The bytes are left exactly as they arrived, so the failure
+				// dump can still show what was really there.
+				if !bytes.Equal(res.BodyBytes, tc.Body) {
+					t.Errorf("BodyBytes was modified despite the decode failing")
+				}
+				return
+			}
+
+			if res.DecodeErr != nil {
+				t.Fatalf("DecodeErr = %s, want nil", res.DecodeErr)
+			}
+			if got := string(res.BodyBytes); got != tc.Want {
+				t.Errorf("BodyBytes = %q, want %q", got, tc.Want)
+			}
+		})
+	}
+}
+
+// Test_decodeBody_leavesHeadersAlone pins the half of the fix that is not about
+// the body. net/http deletes Content-Encoding and Content-Length when it
+// decodes, which makes a compressed response indistinguishable from one that
+// never was -- and telling those apart is the reason to set Accept-Encoding by
+// hand in the first place.
+func Test_decodeBody_leavesHeadersAlone(t *testing.T) {
+	t.Parallel()
+
+	res := encoded("gzip", gzipped(t, payload))
+	res.Header.Set("Content-Length", "44")
+
+	res.decodeBody()
+
+	if got, want := res.Header.Get("Content-Encoding"), "gzip"; got != want {
+		t.Errorf("Content-Encoding = %q, want %q -- the header must survive decoding", got, want)
+	}
+	if got, want := res.Header.Get("Content-Length"), "44"; got != want {
+		t.Errorf("Content-Length = %q, want %q", got, want)
+	}
+}
+
+// Test_bodyOf covers the guard every body assertion goes through.
+func Test_bodyOf(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a decoded body is returned as-is", func(t *testing.T) {
+		res := encoded("gzip", gzipped(t, payload))
+		res.decodeBody()
+
+		body, err := bodyOf(res)
+		checkErr(t, "bodyOf", err, "")
+		if got := string(body); got != payload {
+			t.Errorf("body = %q, want %q", got, payload)
+		}
+	})
+
+	t.Run("an undecoded body is refused, and says why", func(t *testing.T) {
+		res := encoded("br", []byte{0x1b, 0x13, 0x00})
+		res.decodeBody()
+
+		_, err := bodyOf(res)
+		checkErrMatch(t, "bodyOf", err, `^body: response is br-encoded and was not decoded: `)
+	})
+}
+
+// Test_bodyAssertionsRefuseAnEncodedBody: the guard has to be on all three, not
+// on the one that was reported. A missed assertion is a silent false pass.
+func Test_bodyAssertionsRefuseAnEncodedBody(t *testing.T) {
+	t.Parallel()
+
+	// A pattern loose enough to match almost any bytes. Before the guard this
+	// passed against compressed noise, which is the dangerous half of #27: not
+	// a confusing failure, but a green run that checked nothing.
+	match, err := AssertBodyMatch(".")
+	if err != nil {
+		t.Fatalf("cannot build the assertion: %s", err)
+	}
+
+	assertions := map[string]Assertion{
+		"AssertBodyMatch": match,
+		"AssertBodyEqual": AssertBodyEqual(payload),
+		"AssertBodyEmpty": AssertBodyEmpty(),
+	}
+
+	for name, a := range assertions {
+		t.Run(name, func(t *testing.T) {
+			res := encoded("br", []byte{0x1b, 0x13, 0x00})
+			res.decodeBody()
+
+			checkErrMatch(t, name, a(res), `^body: response is br-encoded and was not decoded: `)
+		})
+	}
+}

--- a/e2e_compression_test.go
+++ b/e2e_compression_test.go
@@ -1,0 +1,162 @@
+package main_test
+
+import "testing"
+
+// Compression is the one transformation that sits between the bytes on the wire
+// and what an assertion reads, so what the CLI does with it is worth pinning
+// precisely: which encodings it removes, what it does with one it cannot,
+// which assertions that affects, and what the headers say afterwards.
+//
+// Before #27 was fixed, whether --assert-body saw the payload or a compressed
+// blob depended on a caller-set Accept-Encoding, a Range header, and the
+// server's choice of encoding -- none of which have anything to do with a body.
+
+// TestE2ECompressionDecodesTheBody covers the case in the report and the ways
+// in that it did not mention.
+func TestE2ECompressionDecodesTheBody(t *testing.T) {
+	// The reported invocation, verbatim.
+	t.Run("a caller-set Accept-Encoding", func(t *testing.T) {
+		r := run(t, nil, "-H", "Accept-Encoding: gzip",
+			"--assert-body", `"status":"success"`, url("/gzip"))
+		assertExit(t, r, exitOK)
+	})
+
+	// The transport used to decode only what it had asked for itself, so a
+	// server compressing unbidden broke assertions with no flag involved.
+	t.Run("a server that compresses unasked", func(t *testing.T) {
+		assertExit(t, run(t, nil, "--assert-body", `"status":"success"`, url("/gzip-always")), exitOK)
+	})
+
+	// net/http never negotiates deflate, so it never decoded one either. This
+	// needed no flag to go wrong.
+	t.Run("deflate, raw", func(t *testing.T) {
+		assertExit(t, run(t, nil, "--assert-body", `"status":"success"`, url("/deflate")), exitOK)
+	})
+
+	t.Run("deflate, zlib-wrapped", func(t *testing.T) {
+		assertExit(t, run(t, nil, "--assert-body", `"status":"success"`, url("/deflate-zlib")), exitOK)
+	})
+
+	// A Range header also stopped the transport asking for gzip, and so also
+	// stopped it decoding one.
+	t.Run("a Range header", func(t *testing.T) {
+		r := run(t, nil, "-H", "Range: bytes=0-999",
+			"--assert-body", `"status":"success"`, url("/gzip-always"))
+		assertExit(t, r, exitOK)
+	})
+
+	// All three body assertions, not just the one in the report.
+	t.Run("every body assertion", func(t *testing.T) {
+		for _, args := range [][]string{
+			{"--assert-body", `"status":"success"`},
+			{"--assert-body-eq", `{"status":"success"}`},
+		} {
+			t.Run(args[0], func(t *testing.T) {
+				full := append(append([]string{"-H", "Accept-Encoding: gzip"}, args...), url("/gzip"))
+				assertExit(t, run(t, nil, full...), exitOK)
+			})
+		}
+
+		// --assert-body-empty needs a body that really is empty, and a 204 that
+		// carries the encoding header anyway is the awkward case: there is
+		// nothing to decode, and an empty gzip stream is an error rather than
+		// an empty payload.
+		t.Run("--assert-body-empty", func(t *testing.T) {
+			assertExit(t, run(t, nil, "--assert-body-empty", url("/empty-gzip")), exitOK)
+		})
+	})
+}
+
+// TestE2ECompressionNoFalsePass is the dangerous half of #27. A confusing
+// failure wastes an afternoon; a pattern loose enough to match compressed noise
+// produces a green run that checked nothing, which is the one outcome this
+// program exists to refuse.
+func TestE2ECompressionNoFalsePass(t *testing.T) {
+	// Passes either way -- the point is what it matched. Pair it with a
+	// pattern that can only match the decoded payload.
+	r := run(t, nil, "-H", "Accept-Encoding: gzip",
+		"--assert-body", ".",
+		"--assert-body-eq", `{"status":"success"}`,
+		url("/gzip"))
+	assertExit(t, r, exitOK)
+
+	// And the inverse: a pattern that matches only the compressed form must
+	// now fail, because the compressed form is not what gets asserted on.
+	bad := run(t, nil, "-H", "Accept-Encoding: gzip",
+		"--assert-body", `\x1f\x8b`, url("/gzip"))
+	assertExit(t, bad, exitRequestFail)
+}
+
+// TestE2ECompressionHeadersSurvive pins the half of the fix that is not about
+// the body. net/http deletes Content-Encoding and Content-Length when it
+// decodes, so a response that was compressed became indistinguishable from one
+// that never was -- and telling those apart is the reason to set
+// Accept-Encoding by hand in the first place.
+func TestE2ECompressionHeadersSurvive(t *testing.T) {
+	t.Run("the encoding is still assertable alongside the decoded body", func(t *testing.T) {
+		r := run(t, nil, "-H", "Accept-Encoding: gzip",
+			"--assert-header-eq", "Content-Encoding: gzip",
+			"--assert-body-eq", `{"status":"success"}`,
+			url("/gzip"))
+		assertExit(t, r, exitOK)
+	})
+
+	// The CLI no longer advertises gzip on its own, so a server that only
+	// compresses on request answers in plain -- and says nothing about encoding.
+	t.Run("nothing is advertised unless asked", func(t *testing.T) {
+		r := run(t, nil, "--assert-body", `"headers"`,
+			"--assert-body-eq", "never-matches", url("/echo"))
+		assertExit(t, r, exitRequestFail)
+		assertNotContains(t, r, "Accept-Encoding")
+	})
+}
+
+// TestE2ECompressionUndecodable covers an encoding with no decoder here.
+//
+// The response still has a status and headers worth asserting on, so only the
+// body assertions refuse. Failing the whole run would be simpler and would
+// break a status check against any CDN serving brotli.
+func TestE2ECompressionUndecodable(t *testing.T) {
+	t.Run("a status check is unaffected", func(t *testing.T) {
+		assertExit(t, run(t, nil, "--assert-ok", url("/brotli")), exitOK)
+	})
+
+	t.Run("a header check is unaffected", func(t *testing.T) {
+		r := run(t, nil, "--assert-header-eq", "Content-Encoding: br", url("/brotli"))
+		assertExit(t, r, exitOK)
+	})
+
+	t.Run("a body check refuses, and names the encoding", func(t *testing.T) {
+		r := run(t, nil, "--assert-body", `"status":"success"`, url("/brotli"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "body: response is br-encoded and was not decoded")
+		assertContains(t, r, "no decoder for \"br\"")
+		// The old failure was a bare hex dump with nothing explaining it.
+		assertContains(t, r, "<< Payload is br-encoded and was not decoded >>")
+	})
+
+	// A header claiming an encoding the body does not have. Treating those
+	// bytes as plain would be its own silent corruption.
+	t.Run("a body that does not match its stated encoding", func(t *testing.T) {
+		r := run(t, nil, "--assert-body-eq", `{"status":"success"}`, url("/gzip-corrupt"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "body: response is gzip-encoded and was not decoded")
+	})
+}
+
+// TestE2ECompressionFailureDumpExplainsItself: the headers in the dump still
+// say the body arrived compressed, so plain text underneath needs a word of
+// explanation -- otherwise the dump reads as a contradiction.
+func TestE2ECompressionFailureDumpExplainsItself(t *testing.T) {
+	r := run(t, nil, "-H", "Accept-Encoding: gzip",
+		"--assert-body-eq", "never-matches", url("/gzip"))
+	assertExit(t, r, exitRequestFail)
+
+	assertContains(t, r, "Content-Encoding: gzip")
+	assertContains(t, r, "<< Payload decoded from gzip >>")
+	assertContains(t, r, `{"status":"success"}`)
+
+	// And it stays out of the way when nothing was encoded.
+	plain := run(t, nil, "--assert-body-eq", "never-matches", url("/ok"))
+	assertNotContains(t, plain, "Payload decoded from")
+}

--- a/e2e_known_issues_test.go
+++ b/e2e_known_issues_test.go
@@ -121,22 +121,6 @@ func TestKnownIssue26MaphostErrorDiscarded(t *testing.T) {
 	assertNotContains(t, r, "has no separator")
 }
 
-// TestKnownIssue27GzipBreaksBodyAssertions: setting Accept-Encoding by hand
-// disables Go's transparent decompression, so assertions see compressed bytes.
-func TestKnownIssue27GzipBreaksBodyAssertions(t *testing.T) {
-	t.Run("transparent decompression by default", func(t *testing.T) {
-		assertExit(t, run(t, nil, "--assert-body", `"status":"success"`, url("/gzip")), exitOK)
-	})
-
-	t.Run("caller-set Accept-Encoding breaks it", func(t *testing.T) {
-		characterizes(t, 27, "body assertions run against gzip bytes, with no warning")
-
-		r := run(t, nil, "-H", "Accept-Encoding: gzip", "--assert-body", `"status":"success"`, url("/gzip"))
-		assertExit(t, r, exitRequestFail)
-		assertContains(t, r, "Content-Encoding: gzip")
-	})
-}
-
 // TestKnownIssue28DataDoesNotImplyPost: curl switches to POST for -d; this does not.
 func TestKnownIssue28DataDoesNotImplyPost(t *testing.T) {
 	characterizes(t, 28, "-d keeps the GET method its help text says it changes")

--- a/e2e_server_test.go
+++ b/e2e_server_test.go
@@ -1,7 +1,9 @@
 package main_test
 
 import (
+	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -210,19 +212,65 @@ func testHandler() http.Handler {
 		write(w, http.StatusOK, []byte("slow"), nil)
 	})
 
-	// Compresses only when the client asked, so the suite can exercise both the
-	// transparent-decompression path and the caller-set-the-header path.
+	// The endpoints below exist for #27. Compression is the one transformation
+	// that sits between the bytes on the wire and what an assertion reads, so
+	// each way of applying it gets an endpoint.
+
+	// Compresses only when the client asked. Since the CLI no longer advertises
+	// gzip on its own, this answers plain unless -H says otherwise.
 	mux.HandleFunc("/gzip", func(w http.ResponseWriter, r *http.Request) {
 		raw := []byte(`{"status":"success"}`)
 		if !acceptsGzip(r) {
 			write(w, http.StatusOK, raw, nil)
 			return
 		}
-		w.Header().Set("Content-Encoding", "gzip")
+		writeGzip(w, raw)
+	})
+
+	// Compresses whether or not the client asked, as a CDN with compression
+	// forced on does. Nothing the caller passes can avoid the encoding here.
+	mux.HandleFunc("/gzip-always", func(w http.ResponseWriter, _ *http.Request) {
+		writeGzip(w, []byte(`{"status":"success"}`))
+	})
+
+	// deflate is two formats under one name: RFC 9110 says zlib, and plenty of
+	// servers send raw. Both are served so the guessing can be tested.
+	mux.HandleFunc("/deflate", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "deflate")
 		w.WriteHeader(http.StatusOK)
-		zw := gzip.NewWriter(w)
-		_, _ = zw.Write(raw)
+		zw, _ := flate.NewWriter(w, flate.DefaultCompression)
+		_, _ = zw.Write([]byte(`{"status":"success"}`))
 		_ = zw.Close()
+	})
+
+	mux.HandleFunc("/deflate-zlib", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "deflate")
+		w.WriteHeader(http.StatusOK)
+		zw := zlib.NewWriter(w)
+		_, _ = zw.Write([]byte(`{"status":"success"}`))
+		_ = zw.Close()
+	})
+
+	// An encoding with no decoder here. Brotli is the realistic case; the bytes
+	// are not real brotli because nothing in the suite could produce them, and
+	// the CLI never gets far enough to care.
+	mux.HandleFunc("/brotli", func(w http.ResponseWriter, _ *http.Request) {
+		write(w, http.StatusOK, []byte{0x1b, 0x13, 0x00, 0x00, 0xa4, 0xb0, 0xb2},
+			http.Header{"Content-Encoding": {"br"}})
+	})
+
+	// Claims an encoding and then does not apply it, which is what a corrupt or
+	// truncated stream looks like from here.
+	mux.HandleFunc("/gzip-corrupt", func(w http.ResponseWriter, _ *http.Request) {
+		write(w, http.StatusOK, []byte(`{"status":"success"}`),
+			http.Header{"Content-Encoding": {"gzip"}})
+	})
+
+	// 204 with an encoding header and no body at all. There is nothing to
+	// decode, so --assert-body-empty must still pass.
+	mux.HandleFunc("/empty-gzip", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	// Reflects the request so tests can observe -X, -H and -d taking effect.
@@ -273,6 +321,14 @@ func failCount(r *http.Request) int64 {
 		return math.MaxInt64
 	}
 	return n
+}
+
+func writeGzip(w http.ResponseWriter, raw []byte) {
+	w.Header().Set("Content-Encoding", "gzip")
+	w.WriteHeader(http.StatusOK)
+	zw := gzip.NewWriter(w)
+	_, _ = zw.Write(raw)
+	_ = zw.Close()
 }
 
 func acceptsGzip(r *http.Request) bool {

--- a/main.go
+++ b/main.go
@@ -65,9 +65,26 @@
 // --max-time bounds each attempt; --retry-max-time bounds the whole run. The
 // latter is checked before each retry, so an attempt already in flight can
 // overrun it by up to one --max-time.
+//
+// # Compression
+//
+// A compressed body is decoded before the assertions run, so --assert-body and
+// friends always see the payload. gzip and deflate are understood; an encoding
+// nothing here can remove fails the body assertions by name and leaves every
+// other assertion alone.
+//
+// The request advertises no Accept-Encoding of its own, and the response
+// headers are reported exactly as they arrived. net/http would decode only
+// what it had asked for itself and would delete Content-Encoding and
+// Content-Length on the way, which made a response that was compressed
+// indistinguishable from one that never was.
 package main
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -150,7 +167,17 @@ Retries:
 
   -m bounds each attempt, not the run. --retry-max-time bounds the run and is
   checked before each retry, so an attempt already in flight can overrun it.
-  Both --retry-delay and --retry-max-time need --retry to mean anything.`,
+  Both --retry-delay and --retry-max-time need --retry to mean anything.
+
+Compression:
+  A compressed body is decoded before the assertions run, so --assert-body and
+  the other body assertions always see the payload. gzip and deflate are
+  understood; an encoding with no decoder here fails the body assertions by
+  name and leaves --assert-ok, --assert-status and --assert-header* alone.
+
+  Nothing is advertised in Accept-Encoding unless -H says so, and the response
+  headers are reported exactly as they arrived -- so a body can be asserted on
+  and its Content-Encoding at the same time.`,
 		Example: `  # A health check: any non-error status passes
   http-assert --assert-ok https://example.com/health
 
@@ -761,6 +788,7 @@ func (c Client) doOnce(client *http.Client, req *http.Request, assertions []Asse
 	c.logInfo("[:] %s %s\n", res.Proto, res.Status)
 	httpRes := &httpResponse{Response: res}
 	httpRes.BodyBytes, _ = io.ReadAll(res.Body)
+	httpRes.decodeBody()
 
 	var assertErrors []error
 	for i := range assertions {
@@ -833,7 +861,17 @@ func (c Client) getHttpClient() *http.Client {
 	}
 
 	tr := &http.Transport{
-		ForceAttemptHTTP2:     false,
+		ForceAttemptHTTP2: false,
+		// net/http decodes a gzip response only when it was the layer that
+		// asked for it, and hands over the raw bytes otherwise. Four unrelated
+		// conditions decide which happens -- a caller-set Accept-Encoding, a
+		// Range header, the method, and this field -- so whether --assert-body
+		// saw the payload or a compressed blob depended on flags that have
+		// nothing to do with the body (#27).
+		//
+		// Decoding is done here instead, in decodeBody, on every response. One
+		// path, and the request carries exactly the headers it was told to.
+		DisableCompression:    true,
 		MaxIdleConns:          10,
 		IdleConnTimeout:       20 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
@@ -903,6 +941,98 @@ func (c Client) log(l LogLevel, format string, args ...interface{}) {
 type httpResponse struct {
 	*http.Response
 	BodyBytes []byte
+	// Encoding is the response's Content-Encoding, verbatim, and empty when
+	// there was none.
+	//
+	// The header itself is left alone. net/http deletes it (and Content-Length)
+	// when it decodes, which makes a response that was compressed
+	// indistinguishable from one that never was -- and the whole reason to set
+	// Accept-Encoding by hand is to find out which happened.
+	Encoding string
+	// DecodeErr is why BodyBytes is still encoded. Nil means BodyBytes is the
+	// payload, whether or not anything had to be removed to get there.
+	DecodeErr error
+}
+
+// decoders maps a Content-Encoding to something that removes it. Content
+// coding names are case-insensitive per RFC 9110, so lookups are lowered.
+//
+// deflate is absent by name because it is two formats: RFC 9110 says zlib, and
+// a good deal of the web sends raw. decodeDeflate tries both.
+var decoders = map[string]func([]byte) ([]byte, error){
+	"gzip":    decodeGzip,
+	"deflate": decodeDeflate,
+}
+
+// decodeBody removes the Content-Encoding from BodyBytes, leaving every header
+// exactly as it arrived.
+//
+// An encoding nothing here can remove is not an error by itself: a response
+// body the tool cannot read still has a status and headers worth asserting on.
+// It is recorded instead, and only the body assertions refuse (see bodyOf).
+func (r *httpResponse) decodeBody() {
+	r.Encoding = strings.TrimSpace(r.Header.Get("Content-Encoding"))
+
+	// An empty body has nothing to decode, and an empty gzip stream is an error
+	// rather than an empty payload -- so a 204 that carries the header anyway
+	// must not fail --assert-body-empty.
+	if len(r.BodyBytes) == 0 {
+		return
+	}
+
+	switch enc := strings.ToLower(r.Encoding); enc {
+	case "", "identity":
+		return
+	default:
+		decode, ok := decoders[enc]
+		if !ok {
+			r.DecodeErr = fmt.Errorf("no decoder for %q; gzip and deflate are supported", r.Encoding)
+			return
+		}
+
+		b, err := decode(r.BodyBytes)
+		if err != nil {
+			r.DecodeErr = err
+			return
+		}
+		r.BodyBytes = b
+	}
+}
+
+func decodeGzip(b []byte) ([]byte, error) {
+	zr, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = zr.Close() }()
+
+	return io.ReadAll(zr)
+}
+
+// decodeDeflate tries zlib first and raw DEFLATE second.
+//
+// RFC 9110 defines the deflate coding as the zlib format, but servers sending
+// raw DEFLATE under the same name are common enough that net/http declines to
+// negotiate it at all ("Deflate is ambiguous and not as universally supported
+// anyway", transport.go). Guessing is safe here because neither reader accepts
+// the other's input: a wrong guess fails rather than producing plausible bytes.
+func decodeDeflate(b []byte) ([]byte, error) {
+	if zr, err := zlib.NewReader(bytes.NewReader(b)); err == nil {
+		defer func() { _ = zr.Close() }()
+		if out, err := io.ReadAll(zr); err == nil {
+			return out, nil
+		}
+	}
+
+	fr := flate.NewReader(bytes.NewReader(b))
+	defer func() { _ = fr.Close() }()
+
+	out, err := io.ReadAll(fr)
+	if err != nil {
+		return nil, fmt.Errorf("not valid zlib or raw DEFLATE: %w", err)
+	}
+
+	return out, nil
 }
 
 // maxPayloadBytes is how much of a body the failure dump shows before cropping.
@@ -930,6 +1060,14 @@ func (r httpResponse) writeTo(w io.Writer, withBody bool) {
 	if !withBody {
 		_, _ = fmt.Fprint(w, "  << Payload is omitted >>")
 		return
+	}
+	// The headers above still say how the body arrived, so plain text under a
+	// Content-Encoding header needs explaining -- as does a hex dump under one.
+	switch {
+	case r.DecodeErr != nil:
+		_, _ = fmt.Fprintf(w, "  << Payload is %s-encoded and was not decoded >>\n\n", r.Encoding)
+	case r.Encoding != "" && !strings.EqualFold(r.Encoding, "identity"):
+		_, _ = fmt.Fprintf(w, "  << Payload decoded from %s >>\n\n", r.Encoding)
 	}
 	if cropped := printPayload(w, r.BodyBytes, maxPayloadBytes); cropped > 0 {
 		_, _ = fmt.Fprintf(w, "\n\n  << Payload is cropped: %d bytes are hidden >>", cropped)


### PR DESCRIPTION
## Problem

Body assertions ran against raw compressed bytes, and sometimes passed anyway.

`net/http` decodes a gzip response only when it was the layer that asked for the encoding. Four unrelated conditions decide that — a caller-set `Accept-Encoding`, a `Range` header, the method, and the transport's own flag — so whether `--assert-body` saw the payload or a gzip blob depended on flags that have nothing to do with a body:

```console
$ http-assert -H 'Accept-Encoding: gzip' --assert-body '"status":"success"' $URL
- body: expected to match "\"status\":\"success\"", got "\x1f\x8b\b\x00\x00\x00…"
```

**The reported case was not the only one.** Verified against loopback servers:

| Way in | Flags needed |
|---|---|
| `Content-Encoding: deflate` | **none** — `net/http` never negotiates deflate, so it never decodes one |
| A server compressing unbidden, plus `-H 'Range: …'` | `-H 'Range:'`, which suppresses the transport's own request |
| `-H 'Accept-Encoding: gzip'` | the reported one |

All three body assertions were affected, not just `--assert-body`.

**And the failure was not the worst outcome.** A pattern loose enough to match compressed noise passed:

```console
$ http-assert -H 'Accept-Encoding: gzip' --assert-body '.' $URL
[+] PASSED                       ← exit 0, having matched gzip framing
```

That is a green run reporting a check it never made — the same class as #35, reached through a body type rather than a flag.

## Solution

Decode the body before the assertions run, and stop letting the transport decide.

`DisableCompression` turns off the opportunistic path, so the four conditions stop mattering and there is one route through the code. `decodeBody` then removes the encoding on every response:

```console
$ http-assert -H 'Accept-Encoding: gzip' --assert-body '"status":"success"' $URL
[+] PASSED 41ms
```

`gzip` and `deflate` are understood. deflate is two formats under one name — RFC 9110 says zlib, much of the web sends raw — so both are tried. Guessing is safe because neither reader accepts the other's input: a wrong guess fails rather than producing plausible bytes. Confirmed against zlib, raw, gzip bytes, garbage and empty input.

### Headers are left exactly as they arrived

`net/http` deletes `Content-Encoding` **and** `Content-Length` when it decodes, which makes a response that was compressed indistinguishable from one that never was — and telling those apart is the whole reason to set `Accept-Encoding` by hand. Nothing is deleted here, so a run can assert on both at once:

```bash
http-assert -H 'Accept-Encoding: gzip' \
  --assert-header-eq "Content-Encoding: gzip" \
  --assert-body-eq '{"status":"success"}' $URL
```

This is what forced `DisableCompression` rather than merely adding a decode step alongside Go's. Measured across four server types, keeping Go's auto-decode still left it eating the headers on the rows where it fired; only owning the decode outright gives one rule with no exceptions.

### An undecodable encoding fails the body assertions, not the run

A response the tool cannot read still has a status and headers worth asserting on:

```console
$ http-assert --assert-body '"status":"success"' https://cdn.example.com/
- body: response is br-encoded and was not decoded: no decoder for "br"; gzip and deflate are supported

$ http-assert --assert-ok https://cdn.example.com/
[+] PASSED 38ms
```

Failing the whole run would be simpler and would break a status check against any CDN serving brotli. Neither brotli nor zstd has a decoder in the standard library, so supporting them is a dependency decision rather than a line of code — filed as #77 and #78 and deliberately not made here. `go.mod` is untouched. A header claiming an encoding the body does not have is treated the same way; reading those bytes as plain text would be its own silent corruption.

The failure dump says which happened, because the headers above it still describe the wire:

```
Content-Encoding: gzip

  << Payload decoded from gzip >>

{"status":"success"}
```

## Other Changes

The request no longer advertises `Accept-Encoding` of its own. Two consequences worth stating plainly, since both are behaviour changes rather than pure fixes:

- A server that compresses only on request now answers in plain, so bodies travel uncompressed unless `-H` asks otherwise.
- A server that compresses regardless now has its `Content-Encoding` and `Content-Length` **reported** rather than swallowed — so `--assert-header-missing Content-Encoding` flips from passing to failing against one, and `Content-Length` becomes assertable where it previously could not be. Both are the header telling the truth.

`TestKnownIssue27GzipBreaksBodyAssertions` is deleted; `e2e_compression_test.go` replaces it with the fixed expectations plus the three ways in the issue did not mention. Six endpoints on the e2e server cover gzip-on-request, gzip-always, raw and zlib deflate, an undecodable encoding, a body contradicting its own header, and a 204 that carries an encoding header with no body.

Unit coverage is a table over every way a body can arrive — including case-insensitive coding names per RFC 9110, whitespace around the header value, and a truncated stream — asserting the payload, the recorded encoding, and that the bytes are left untouched when decoding fails.

The second commit is a documentation pass with no behaviour in it. Five passages across the README explained the implementation rather than the behaviour — what the tool is written in, which library parses a flag — none of which help a reader predict what will happen. Facts stayed, reasons went; the reasons are still in the commits that introduced them and in the package comment. `curl` comparisons stayed, being what readers arrive from rather than an internal detail. Two of the five predate this branch.

There are no screenshots because there is no rendered UI; this tool's user-visible surface is terminal output, shown inline above.

## Notes for the reviewer

`decodeBody` runs on every attempt, including retried ones, because it sits inside the per-attempt path rather than around it. That is deliberate — each attempt gets its own response.

The three body assertions now share one guard rather than repeating the check. That is the part that actually restores the invariant; `DisableCompression` and the decoder are what make the guard possible.

Closes #27

Related:
- https://github.com/korya/http-assert/issues/77 — decode brotli, opened by this work
- https://github.com/korya/http-assert/issues/78 — decode zstd, same dependency question
- https://github.com/korya/http-assert/issues/35 — the same failure mode (a green run that checked nothing), reached through a repeated flag
- https://github.com/korya/http-assert/issues/45 — `--json` wants the decoded body, which now exists
- https://github.com/korya/http-assert/issues/71 — untouched; an undecodable body is still exit `93`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EMMhgmTkbzAsmeNy97PrP
