### PR TITLE
Let an empty body satisfy a body assertion

### DIFF
--- a/assertions.go
+++ b/assertions.go
@@ -142,11 +142,15 @@ func AssertBodyEqual(expContent string) Assertion {
 			return err
 		}
 
-		if len(body) == 0 {
-			return fmt.Errorf("body: expected %q, missing", expContent)
-		}
-
 		if c := string(body); expContent != c {
+			// "missing" reads better than `got ""` for the common case of an
+			// empty body where content was expected, but it is a wording
+			// choice inside the failure -- deciding the verdict on it is what
+			// made --assert-body-eq '' impossible to satisfy (#22).
+			if len(body) == 0 {
+				return fmt.Errorf("body: expected %q, missing", expContent)
+			}
+
 			return fmt.Errorf("body: expected %q, got %q", expContent, c)
 		}
 
@@ -166,11 +170,14 @@ func AssertBodyMatch(expPattern string) (Assertion, error) {
 			return err
 		}
 
-		if len(body) == 0 {
-			return fmt.Errorf("body: expected to match %q, missing", expPattern)
-		}
-
 		if c := string(body); !re.MatchString(c) {
+			// As above: an empty body is a legitimate subject for a pattern.
+			// `^$`, `.*` and `\A\z` all match it, and none of them could pass
+			// while emptiness was checked before the pattern was.
+			if len(body) == 0 {
+				return fmt.Errorf("body: expected to match %q, missing", expPattern)
+			}
+
 			return fmt.Errorf("body: expected to match %q, got %q", expPattern, c)
 		}
 

--- a/assertions_test.go
+++ b/assertions_test.go
@@ -284,6 +284,57 @@ func Test_AssertBody(t *testing.T) {
 	}
 }
 
+// Test_AssertBody_emptyIsAssertable covers the expectations that an empty body
+// satisfies. They were unreachable while emptiness was checked before the
+// comparison: the guard existed to word the failure nicely and ended up
+// deciding it (#22).
+func Test_AssertBody_emptyIsAssertable(t *testing.T) {
+	t.Parallel()
+
+	// Patterns an empty body legitimately matches. `.*` is the one a user is
+	// most likely to reach for, `^$` the one they mean.
+	patterns := []string{"^$", ".*", `\A\z`, ""}
+
+	t.Run("equal to the empty string", func(t *testing.T) {
+		res := &httpResponse{BodyBytes: []byte{}}
+		checkErr(t, "equal", AssertBodyEqual("")(res), "")
+
+		// And a nil body, which is what a 204 produces.
+		checkErr(t, "equal, nil body", AssertBodyEqual("")(&httpResponse{}), "")
+	})
+
+	for _, p := range patterns {
+		t.Run("matching "+strconv.Quote(p), func(t *testing.T) {
+			a, err := AssertBodyMatch(p)
+			if err != nil {
+				t.Fatalf("cannot build the assertion: %s", err)
+			}
+
+			checkErr(t, "match", a(&httpResponse{BodyBytes: []byte{}}), "")
+			checkErr(t, "match, nil body", a(&httpResponse{}), "")
+		})
+	}
+
+	// The verdict moved; the wording did not. A body that is empty when
+	// something was expected still reads as "missing" rather than `got ""`.
+	t.Run("an empty body still reports as missing", func(t *testing.T) {
+		res := &httpResponse{BodyBytes: []byte{}}
+		checkErr(t, "equal", AssertBodyEqual("value")(res), `body: expected "value", missing`)
+
+		a, err := AssertBodyMatch("^value$")
+		if err != nil {
+			t.Fatalf("cannot build the assertion: %s", err)
+		}
+		checkErr(t, "match", a(res), `body: expected to match "^value$", missing`)
+	})
+
+	// The inverse must keep failing: a non-empty body is not the empty string.
+	t.Run("a non-empty body does not equal the empty string", func(t *testing.T) {
+		res := &httpResponse{BodyBytes: []byte("x")}
+		checkErr(t, "equal", AssertBodyEqual("")(res), `body: expected "", got "x"`)
+	})
+}
+
 func Test_AssertRedirect(t *testing.T) {
 	t.Parallel()
 

--- a/e2e_assert_test.go
+++ b/e2e_assert_test.go
@@ -221,3 +221,32 @@ func TestE2ELargePayloadCropped(t *testing.T) {
 	assertContains(t, r, "Payload is cropped")
 	assertContains(t, r, "4744 bytes are hidden")
 }
+
+// TestE2EAssertEmptyBody covers the expectations an empty body satisfies.
+//
+// They were unreachable until #22: both --assert-body-eq and --assert-body
+// checked whether the body was empty before checking what was asked of it, so
+// a 204 could not be asserted to have the body a 204 is defined to have.
+func TestE2EAssertEmptyBody(t *testing.T) {
+	t.Run("--assert-body-eq '' passes against a 204", func(t *testing.T) {
+		assertExit(t, run(t, nil, "--assert-body-eq", "", url("/empty")), exitOK)
+	})
+
+	t.Run("--assert-body '^$' passes against a 204", func(t *testing.T) {
+		assertExit(t, run(t, nil, "--assert-body", "^$", url("/empty")), exitOK)
+	})
+
+	// The inverse still fails, so the fix did not simply stop checking.
+	t.Run("--assert-body-eq '' fails against a body", func(t *testing.T) {
+		r := run(t, nil, "--assert-body-eq", "", url("/ok"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, `body: expected "", got`)
+	})
+
+	// And the wording that the old guard existed to produce is still there.
+	t.Run("an empty body still reports as missing", func(t *testing.T) {
+		r := run(t, nil, "--assert-body-eq", "value", url("/empty"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, `body: expected "value", missing`)
+	})
+}

--- a/e2e_known_issues_test.go
+++ b/e2e_known_issues_test.go
@@ -76,16 +76,6 @@ func TestKnownIssue20AssertOkAcceptsRedirects(t *testing.T) {
 	}
 }
 
-// TestKnownIssue22EmptyBodyEqualsNeverPasses: --assert-body-eq "" short-circuits
-// on an empty body and reports that the empty string is "missing".
-func TestKnownIssue22EmptyBodyEqualsNeverPasses(t *testing.T) {
-	characterizes(t, 22, `--assert-body-eq "" cannot pass, even against a 204`)
-
-	r := run(t, nil, "--assert-body-eq", "", url("/empty"))
-	assertExit(t, r, exitRequestFail)
-	assertContains(t, r, `body: expected "", missing`)
-}
-
 // TestKnownIssue23WildcardMaphostUnreachable: hostMapping.Matches handles "*"
 // and "*:*", but the parser rejects both, so the branches are dead code.
 func TestKnownIssue23WildcardMaphostUnreachable(t *testing.T) {


### PR DESCRIPTION
## Problem

`--assert-body-eq ''` could never pass, and the failure said so in a way that refuted itself.

Both `--assert-body-eq` and `--assert-body` checked whether the body was empty *before* checking what had been asked of them:

```console
$ http-assert --assert-body-eq '' http://…/empty     # a 204
- body: expected "", missing
```

The empty string is not missing — it is exactly what was asked for. So a `204 No Content` could not be asserted to have the body a 204 is *defined* to have.

`--assert-body` has the same shape, which makes every pattern that legitimately matches an empty body unreachable: `^$`, `.*`, `\A\z` and the empty pattern all fail against a 204 no matter what the response is.

## Solution

Let the comparison decide the verdict, and keep the guard for what it was actually good at.

"missing" reads better than `got ""` when content was expected and none arrived — that is a genuine improvement to the failure message, and it is worth keeping. It just had no business running *before* the comparison. It now runs inside the failure branch:

```console
$ http-assert --assert-body-eq '' http://…/empty
[+] PASSED 1ms

$ http-assert --assert-body-eq 'value' http://…/empty
- body: expected "value", missing        ← wording preserved

$ http-assert --assert-body-eq '' http://…/ok
- body: expected "", got "{\"status\":\"success\"}"
```

The inverse still fails, so this is not "stopped checking dressed up as fixed".

## Other Changes

`TestKnownIssue22EmptyBodyEqualsNeverPasses` is deleted and replaced by `TestE2EAssertEmptyBody`, which covers both directions: the expectations an empty body now satisfies, and the ones it still must not.

Unit coverage adds the four patterns an empty body legitimately matches, both an empty and a nil `BodyBytes` (a 204 produces the latter), and a check that the "missing" wording survived. The existing table needed no changes — empty-body-versus-`"value"` still reports exactly what it did before, which is the evidence the message was preserved rather than sacrificed.

No README change: nothing in it described the broken behaviour, so there is nothing to correct.

There are no screenshots because there is no rendered UI; this tool's user-visible surface is terminal output, shown inline above.

Closes #22

Related:
- https://github.com/korya/http-assert/issues/32 — next in this stack; also an assertion that silently does less than asked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EMMhgmTkbzAsmeNy97PrP
