### PR TITLE
Default the method to POST when -d is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ http-assert [flags] <URL>
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--request` | `-X` | HTTP method (default: GET) |
-| `--data` | `-d` | Request body data |
+| `--request` | `-X` | HTTP method (default: GET, or POST when `-d` is given) |
+| `--data` | `-d` | Request body data; implies POST and `Content-Type: application/x-www-form-urlencoded` unless overridden |
 | `--header` | `-H` | Set request headers as `name: value` (can be used multiple times) |
 | `--max-time` | `-m` | Request timeout in seconds (default: 20) |
 | `--insecure` | `-k` | Skip SSL certificate verification |
@@ -75,6 +75,8 @@ http-assert [flags] <URL>
 | `--retry-max-time` | | Stop retrying after this long (default: no limit) |
 
 A `-H` value needs a colon. A bare name exits `71` rather than being sent as a header with an empty value, which is what `curl` reads as "remove this header" — so the two would have meant opposite things. Write `-H 'X-Foo:'` when an empty value is what you want.
+
+`-d` follows `curl`: the method becomes POST unless `-X` says otherwise, and `Content-Type: application/x-www-form-urlencoded` is set unless a `-H` provides one (`-H 'Content-Type:'` counts as providing one). Two deviations remain: `-d @file` sends the literal string `@file` rather than reading the file, and a repeated `-d` is rejected rather than joined with `&`.
 
 ### Assertion Options
 

--- a/e2e_assert_test.go
+++ b/e2e_assert_test.go
@@ -127,6 +127,92 @@ func TestE2ERequestOptions(t *testing.T) {
 	})
 }
 
+// TestE2EDataImpliesPost pins that -d implies POST and curl's default
+// Content-Type, with -X and an explicit Content-Type header overriding.
+//
+// This lived in the known-issues file asserting that the method stayed GET;
+// it flipped when #28 was fixed.
+func TestE2EDataImpliesPost(t *testing.T) {
+	for _, tc := range []struct {
+		Name    string
+		Args    []string
+		Want    []string
+		NotWant []string
+	}{
+		{
+			Name: "bare -d implies POST and form Content-Type",
+			Args: []string{"-d", "hello=1"},
+			Want: []string{`\"method\":\"POST\"`, `\"body\":\"hello=1\"`,
+				"application/x-www-form-urlencoded"},
+		},
+		{
+			// The Content-Type follows -d, not the implied method, as in curl.
+			Name: "-X wins over -d, keeping the form Content-Type",
+			Args: []string{"-X", "PUT", "-d", "hello=1"},
+			Want: []string{`\"method\":\"PUT\"`, "application/x-www-form-urlencoded"},
+		},
+		{
+			Name: "explicit -X GET wins even against the default",
+			Args: []string{"-X", "GET", "-d", "hello=1"},
+			Want: []string{`\"method\":\"GET\"`},
+		},
+		{
+			Name:    "an explicit Content-Type is not replaced",
+			Args:    []string{"-d", "{}", "-H", "Content-Type: application/json"},
+			Want:    []string{`\"method\":\"POST\"`, "application/json"},
+			NotWant: []string{"application/x-www-form-urlencoded"},
+		},
+		{
+			Name: "empty -d still posts an empty body, with the form Content-Type",
+			Args: []string{"-d", ""},
+			Want: []string{`\"method\":\"POST\"`, `\"body\":\"\"`,
+				"application/x-www-form-urlencoded"},
+		},
+		{
+			Name:    "without -d nothing changes: GET, no Content-Type",
+			Args:    nil,
+			Want:    []string{`\"method\":\"GET\"`},
+			NotWant: []string{"application/x-www-form-urlencoded"},
+		},
+		{
+			// The suppression idiom from the README: an empty Content-Type
+			// counts as given, so the form default must not overwrite it.
+			Name:    "empty Content-Type header suppresses the default",
+			Args:    []string{"-d", "hello=1", "-H", "Content-Type:"},
+			Want:    []string{`\"method\":\"POST\"`},
+			NotWant: []string{"application/x-www-form-urlencoded"},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			args := append(tc.Args, "--assert-body-eq", "never-matches", url("/echo"))
+			r := run(t, nil, args...)
+			for _, want := range tc.Want {
+				assertContains(t, r, want)
+			}
+			for _, notWant := range tc.NotWant {
+				assertNotContains(t, r, notWant)
+			}
+		})
+	}
+
+	// The implied POST goes through the same replay machinery as an explicit
+	// one; these mirror the -X POST cases in the redirect and retry suites.
+	t.Run("308 replays the implied method and body", func(t *testing.T) {
+		r := run(t, nil, "-L", "-d", "replayed-payload",
+			"--assert-body", `"body":"replayed-payload".*"method":"POST"`,
+			url("/redirect-308"))
+		assertExit(t, r, exitOK)
+	})
+
+	t.Run("the implied POST body survives a retry", func(t *testing.T) {
+		r := run(t, nil, "--retry", "3", "--retry-delay", "50ms",
+			"-d", "replayed-payload",
+			"--assert-body", `"body":"replayed-payload".*"method":"POST"`,
+			flaky(t, "/flaky-echo", 2))
+		assertExit(t, r, exitOK)
+	})
+}
+
 // TestE2EHostMapping covers the option that distinguishes this tool from curl.
 func TestE2EHostMapping(t *testing.T) {
 	target := "http://mapped.invalid/ok"
@@ -376,5 +462,37 @@ func TestE2EHeaderRequiresASeparator(t *testing.T) {
 			assertExit(t, r, exitOK)
 		}
 		assertExit(t, run(t, nil, "--assert-header-missing", "X-Absent", url("/ok")), exitOK)
+	})
+}
+
+// TestE2EBadPatternIsRejected pins that an unparseable pattern is reported
+// as an invalid flag value rather than reaching the runtime as a panic.
+//
+// This lived in the known-issues file asserting the panic; it flipped when
+// #17 was fixed.
+func TestE2EBadPatternIsRejected(t *testing.T) {
+	for _, tc := range []struct {
+		Flag string
+		Arg  string
+	}{
+		{"--assert-body", "[unclosed"},
+		{"--assert-header", "X-Any: (unclosed"},
+		{"--assert-redirect", "[unclosed"},
+	} {
+		t.Run(tc.Flag, func(t *testing.T) {
+			r := run(t, nil, tc.Flag, tc.Arg, url("/ok"))
+
+			assertExit(t, r, exitBadFlagVal)
+			// The flag at fault is named, and the parser's reason survives.
+			assertContains(t, r, "Invalid value for "+tc.Flag+" flag")
+			assertContains(t, r, "error parsing regexp")
+			assertNotContains(t, r, "panic:")
+			assertNotContains(t, r, "goroutine")
+		})
+	}
+
+	// A pattern that compiles is unaffected.
+	t.Run("valid patterns still work", func(t *testing.T) {
+		assertExit(t, run(t, nil, "--assert-body", `"status":\s*"success"`, url("/ok")), exitOK)
 	})
 }

--- a/e2e_known_issues_test.go
+++ b/e2e_known_issues_test.go
@@ -11,38 +11,6 @@ import "testing"
 //
 //	go test -run 'TestKnown' ./...
 
-// TestIssue17BadPatternIsRejected pins that an unparseable pattern is reported
-// as an invalid flag value rather than reaching the runtime as a panic.
-//
-// This test previously asserted the panic. It flipped when #17 was fixed, which
-// is the record of that change.
-func TestIssue17BadPatternIsRejected(t *testing.T) {
-	for _, tc := range []struct {
-		Flag string
-		Arg  string
-	}{
-		{"--assert-body", "[unclosed"},
-		{"--assert-header", "X-Any: (unclosed"},
-		{"--assert-redirect", "[unclosed"},
-	} {
-		t.Run(tc.Flag, func(t *testing.T) {
-			r := run(t, nil, tc.Flag, tc.Arg, url("/ok"))
-
-			assertExit(t, r, exitBadFlagVal)
-			// The flag at fault is named, and the parser's reason survives.
-			assertContains(t, r, "Invalid value for "+tc.Flag+" flag")
-			assertContains(t, r, "error parsing regexp")
-			assertNotContains(t, r, "panic:")
-			assertNotContains(t, r, "goroutine")
-		})
-	}
-
-	// A pattern that compiles is unaffected.
-	t.Run("valid patterns still work", func(t *testing.T) {
-		assertExit(t, run(t, nil, "--assert-body", `"status":\s*"success"`, url("/ok")), exitOK)
-	})
-}
-
 // TestKnownIssue20AssertOkAcceptsRedirects: --assert-ok is documented as "2xx"
 // but implemented as 200-399.
 func TestKnownIssue20AssertOkAcceptsRedirects(t *testing.T) {
@@ -87,92 +55,6 @@ func TestKnownIssue26MaphostErrorDiscarded(t *testing.T) {
 	assertExit(t, r, exitBadFlagVal)
 	assertContains(t, r, "Invalid value for --maphost flag: [garbage]")
 	assertNotContains(t, r, "has no separator")
-}
-
-// TestIssue28DataImpliesPost pins that -d implies POST and curl's default
-// Content-Type, with -X and an explicit Content-Type header overriding.
-//
-// This test previously asserted that the method stayed GET. It flipped when
-// #28 was fixed, which is the record of that change.
-func TestIssue28DataImpliesPost(t *testing.T) {
-	for _, tc := range []struct {
-		Name    string
-		Args    []string
-		Want    []string
-		NotWant []string
-	}{
-		{
-			Name: "bare -d implies POST and form Content-Type",
-			Args: []string{"-d", "hello=1"},
-			Want: []string{`\"method\":\"POST\"`, `\"body\":\"hello=1\"`,
-				"application/x-www-form-urlencoded"},
-		},
-		{
-			// The Content-Type follows -d, not the implied method, as in curl.
-			Name: "-X wins over -d, keeping the form Content-Type",
-			Args: []string{"-X", "PUT", "-d", "hello=1"},
-			Want: []string{`\"method\":\"PUT\"`, "application/x-www-form-urlencoded"},
-		},
-		{
-			Name: "explicit -X GET wins even against the default",
-			Args: []string{"-X", "GET", "-d", "hello=1"},
-			Want: []string{`\"method\":\"GET\"`},
-		},
-		{
-			Name:    "an explicit Content-Type is not replaced",
-			Args:    []string{"-d", "{}", "-H", "Content-Type: application/json"},
-			Want:    []string{`\"method\":\"POST\"`, "application/json"},
-			NotWant: []string{"application/x-www-form-urlencoded"},
-		},
-		{
-			Name: "empty -d still posts an empty body, with the form Content-Type",
-			Args: []string{"-d", ""},
-			Want: []string{`\"method\":\"POST\"`, `\"body\":\"\"`,
-				"application/x-www-form-urlencoded"},
-		},
-		{
-			Name:    "without -d nothing changes: GET, no Content-Type",
-			Args:    nil,
-			Want:    []string{`\"method\":\"GET\"`},
-			NotWant: []string{"application/x-www-form-urlencoded"},
-		},
-		{
-			// The suppression idiom from the README: an empty Content-Type
-			// counts as given, so the form default must not overwrite it.
-			Name:    "empty Content-Type header suppresses the default",
-			Args:    []string{"-d", "hello=1", "-H", "Content-Type:"},
-			Want:    []string{`\"method\":\"POST\"`},
-			NotWant: []string{"application/x-www-form-urlencoded"},
-		},
-	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			args := append(tc.Args, "--assert-body-eq", "never-matches", url("/echo"))
-			r := run(t, nil, args...)
-			for _, want := range tc.Want {
-				assertContains(t, r, want)
-			}
-			for _, notWant := range tc.NotWant {
-				assertNotContains(t, r, notWant)
-			}
-		})
-	}
-
-	// The implied POST goes through the same replay machinery as an explicit
-	// one; these mirror the -X POST cases in the redirect and retry suites.
-	t.Run("308 replays the implied method and body", func(t *testing.T) {
-		r := run(t, nil, "-L", "-d", "replayed-payload",
-			"--assert-body", `"body":"replayed-payload".*"method":"POST"`,
-			url("/redirect-308"))
-		assertExit(t, r, exitOK)
-	})
-
-	t.Run("the implied POST body survives a retry", func(t *testing.T) {
-		r := run(t, nil, "--retry", "3", "--retry-delay", "50ms",
-			"-d", "replayed-payload",
-			"--assert-body", `"body":"replayed-payload".*"method":"POST"`,
-			flaky(t, "/flaky-echo", 2))
-		assertExit(t, r, exitOK)
-	})
 }
 
 // TestKnownIssue31MaxTimeAcceptsNonPositive: values <= 0 reach http.Client.Timeout,

--- a/e2e_known_issues_test.go
+++ b/e2e_known_issues_test.go
@@ -89,12 +89,59 @@ func TestKnownIssue26MaphostErrorDiscarded(t *testing.T) {
 	assertNotContains(t, r, "has no separator")
 }
 
-// TestKnownIssue28DataDoesNotImplyPost: curl switches to POST for -d; this does not.
-func TestKnownIssue28DataDoesNotImplyPost(t *testing.T) {
-	characterizes(t, 28, "-d keeps the GET method its help text says it changes")
+// TestIssue28DataImpliesPost pins that -d implies POST and curl's default
+// Content-Type, with -X and an explicit Content-Type header overriding.
+//
+// This test previously asserted that the method stayed GET. It flipped when
+// #28 was fixed, which is the record of that change.
+func TestIssue28DataImpliesPost(t *testing.T) {
+	for _, tc := range []struct {
+		Name string
+		Args []string
+		Want []string
+	}{
+		{
+			"bare -d implies POST and form Content-Type",
+			[]string{"-d", "hello=1"},
+			[]string{`\"method\":\"POST\"`, "application/x-www-form-urlencoded"},
+		},
+		{
+			"-X wins over -d",
+			[]string{"-X", "PUT", "-d", "hello=1"},
+			[]string{`\"method\":\"PUT\"`},
+		},
+		{
+			"explicit -X GET wins even against the default",
+			[]string{"-X", "GET", "-d", "hello=1"},
+			[]string{`\"method\":\"GET\"`},
+		},
+		{
+			"an explicit Content-Type is not replaced",
+			[]string{"-d", "{}", "-H", "Content-Type: application/json"},
+			[]string{`\"method\":\"POST\"`, "application/json"},
+		},
+		{
+			"empty -d still posts, with an empty body",
+			[]string{"-d", ""},
+			[]string{`\"method\":\"POST\"`, `\"body\":\"\"`},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			args := append(tc.Args, "--assert-body-eq", "never-matches", url("/echo"))
+			r := run(t, nil, args...)
+			for _, want := range tc.Want {
+				assertContains(t, r, want)
+			}
+		})
+	}
 
-	r := run(t, nil, "-d", "payload", "--assert-body-eq", "never-matches", url("/echo"))
-	assertContains(t, r, `\"method\":\"GET\"`)
+	// The suppression idiom from the README: an empty Content-Type counts as
+	// given, so the form default must not overwrite it.
+	t.Run("empty Content-Type header suppresses the default", func(t *testing.T) {
+		r := run(t, nil, "-d", "hello=1", "-H", "Content-Type:",
+			"--assert-body-eq", "never-matches", url("/echo"))
+		assertNotContains(t, r, "application/x-www-form-urlencoded")
+	})
 }
 
 // TestKnownIssue31MaxTimeAcceptsNonPositive: values <= 0 reach http.Client.Timeout,

--- a/e2e_known_issues_test.go
+++ b/e2e_known_issues_test.go
@@ -96,34 +96,53 @@ func TestKnownIssue26MaphostErrorDiscarded(t *testing.T) {
 // #28 was fixed, which is the record of that change.
 func TestIssue28DataImpliesPost(t *testing.T) {
 	for _, tc := range []struct {
-		Name string
-		Args []string
-		Want []string
+		Name    string
+		Args    []string
+		Want    []string
+		NotWant []string
 	}{
 		{
-			"bare -d implies POST and form Content-Type",
-			[]string{"-d", "hello=1"},
-			[]string{`\"method\":\"POST\"`, "application/x-www-form-urlencoded"},
+			Name: "bare -d implies POST and form Content-Type",
+			Args: []string{"-d", "hello=1"},
+			Want: []string{`\"method\":\"POST\"`, `\"body\":\"hello=1\"`,
+				"application/x-www-form-urlencoded"},
 		},
 		{
-			"-X wins over -d",
-			[]string{"-X", "PUT", "-d", "hello=1"},
-			[]string{`\"method\":\"PUT\"`},
+			// The Content-Type follows -d, not the implied method, as in curl.
+			Name: "-X wins over -d, keeping the form Content-Type",
+			Args: []string{"-X", "PUT", "-d", "hello=1"},
+			Want: []string{`\"method\":\"PUT\"`, "application/x-www-form-urlencoded"},
 		},
 		{
-			"explicit -X GET wins even against the default",
-			[]string{"-X", "GET", "-d", "hello=1"},
-			[]string{`\"method\":\"GET\"`},
+			Name: "explicit -X GET wins even against the default",
+			Args: []string{"-X", "GET", "-d", "hello=1"},
+			Want: []string{`\"method\":\"GET\"`},
 		},
 		{
-			"an explicit Content-Type is not replaced",
-			[]string{"-d", "{}", "-H", "Content-Type: application/json"},
-			[]string{`\"method\":\"POST\"`, "application/json"},
+			Name:    "an explicit Content-Type is not replaced",
+			Args:    []string{"-d", "{}", "-H", "Content-Type: application/json"},
+			Want:    []string{`\"method\":\"POST\"`, "application/json"},
+			NotWant: []string{"application/x-www-form-urlencoded"},
 		},
 		{
-			"empty -d still posts, with an empty body",
-			[]string{"-d", ""},
-			[]string{`\"method\":\"POST\"`, `\"body\":\"\"`},
+			Name: "empty -d still posts an empty body, with the form Content-Type",
+			Args: []string{"-d", ""},
+			Want: []string{`\"method\":\"POST\"`, `\"body\":\"\"`,
+				"application/x-www-form-urlencoded"},
+		},
+		{
+			Name:    "without -d nothing changes: GET, no Content-Type",
+			Args:    nil,
+			Want:    []string{`\"method\":\"GET\"`},
+			NotWant: []string{"application/x-www-form-urlencoded"},
+		},
+		{
+			// The suppression idiom from the README: an empty Content-Type
+			// counts as given, so the form default must not overwrite it.
+			Name:    "empty Content-Type header suppresses the default",
+			Args:    []string{"-d", "hello=1", "-H", "Content-Type:"},
+			Want:    []string{`\"method\":\"POST\"`},
+			NotWant: []string{"application/x-www-form-urlencoded"},
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -132,15 +151,27 @@ func TestIssue28DataImpliesPost(t *testing.T) {
 			for _, want := range tc.Want {
 				assertContains(t, r, want)
 			}
+			for _, notWant := range tc.NotWant {
+				assertNotContains(t, r, notWant)
+			}
 		})
 	}
 
-	// The suppression idiom from the README: an empty Content-Type counts as
-	// given, so the form default must not overwrite it.
-	t.Run("empty Content-Type header suppresses the default", func(t *testing.T) {
-		r := run(t, nil, "-d", "hello=1", "-H", "Content-Type:",
-			"--assert-body-eq", "never-matches", url("/echo"))
-		assertNotContains(t, r, "application/x-www-form-urlencoded")
+	// The implied POST goes through the same replay machinery as an explicit
+	// one; these mirror the -X POST cases in the redirect and retry suites.
+	t.Run("308 replays the implied method and body", func(t *testing.T) {
+		r := run(t, nil, "-L", "-d", "replayed-payload",
+			"--assert-body", `"body":"replayed-payload".*"method":"POST"`,
+			url("/redirect-308"))
+		assertExit(t, r, exitOK)
+	})
+
+	t.Run("the implied POST body survives a retry", func(t *testing.T) {
+		r := run(t, nil, "--retry", "3", "--retry-delay", "50ms",
+			"-d", "replayed-payload",
+			"--assert-body", `"body":"replayed-payload".*"method":"POST"`,
+			flaky(t, "/flaky-echo", 2))
+		assertExit(t, r, exitOK)
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -224,9 +224,18 @@ Compression:
 			}
 			c.Init()
 
+			// -d implies POST, as it does in curl; an explicit -X wins even
+			// when it repeats the default, which Changed distinguishes from
+			// "not passed" -- applyEnv cannot fake it because neither flag is
+			// env-applied and Value.Set does not mark Changed.
 			m, _ := cmd.Flags().GetString("request")
+			dataGiven := cmd.Flags().Changed("data")
+			if dataGiven && !cmd.Flags().Changed("request") {
+				m = http.MethodPost
+			}
 			b := io.Reader(http.NoBody)
-			if d, _ := cmd.Flags().GetString("data"); d != "" {
+			if dataGiven {
+				d, _ := cmd.Flags().GetString("data")
 				b = strings.NewReader(d)
 			}
 			req, err := http.NewRequestWithContext(cmd.Context(), m, args[0], b)
@@ -238,6 +247,11 @@ Compression:
 			for _, v := range vs {
 				name, value := mustParseRequestHeader(v)
 				req.Header.Add(name, value)
+			}
+			// curl's default for -d; presence is what suppresses it, so an
+			// explicit empty `-H 'Content-Type:'` is respected, not replaced.
+			if dataGiven && len(req.Header.Values("Content-Type")) == 0 {
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 			}
 			if err := c.Do(req, parseAssertionFlags(cmd)...); err != nil {
 				dief(93, "Cannot perform request: %s", err)
@@ -259,7 +273,8 @@ Compression:
 	cmd.PersistentFlags().BoolP("insecure", "k", false, "Disable checking SSL certificates")
 	cmd.PersistentFlags().IntP("max-time", "m", 20,
 		"Maximum time in seconds that you allow each request to take")
-	cmd.Flags().StringP("request", "X", "GET", "Set method for HTTP request")
+	cmd.Flags().StringP("request", "X", "GET",
+		"Set method for HTTP request; overrides the POST that -d implies")
 	cmd.Flags().StringArrayP("header", "H", nil,
 		"Set header for HTTP request, as <name: value>; a name alone is rejected")
 	cmd.Flags().StringP("data", "d", "",


### PR DESCRIPTION
## Problem

Passing `-d` sent a GET with a body, even though the help text — copied from curl — promised a POST. curl users get a request almost nobody means, and the one reference available at the terminal actively misleads them.

## Solution

Match curl: `-d` now implies POST and sets `Content-Type: application/x-www-form-urlencoded`, unless `-X` or an explicit `Content-Type` header overrides.

**Before:**
```console
$ http-assert -d 'hello=1' --assert-ok http://127.0.0.1:8791/echo
[.] HTTP/1.1 GET http://127.0.0.1:8791/echo
```

**After:**
```console
$ http-assert -d 'hello=1' --assert-ok http://127.0.0.1:8791/echo
[.] HTTP/1.1 POST http://127.0.0.1:8791/echo      # Content-Type: application/x-www-form-urlencoded
```

Details that the diff can't tell you on its own:

- "`-X` was passed" is detected via pflag's `Changed`, which only command-line parsing sets — `applyEnv` writes through `Value.Set` and neither `request` nor `data` is env-applied, so the environment cannot flip the method. An explicit `-X GET` therefore beats the implication, exactly as in curl.
- The Content-Type default is suppressed by *presence* of a user-supplied header, not by a non-empty value — so the README's `-H 'Content-Type:'` empty-value idiom is respected rather than overwritten.
- `-d ''` now sends an empty-body POST instead of being a silent no-op (previously the `d != ""` guard dropped both the body and, under the new rule, would have dropped the implication).
- **Deliberate behaviour break:** scripts that passed `-d` without `-X` and relied on the GET will now POST. That GET-with-a-body was the defect #28 names, so the break is the fix.
- Still divergent from curl, now documented in the README: `-d @file` sends the literal string, and a repeated `-d` is rejected rather than joined with `&`.

## Other Changes

- The pinned characterization test flipped per the known-issues protocol and now lives in `e2e_assert_test.go` as `TestE2EDataImpliesPost`, next to the other request-shaping tests. Nine cases cover the full surface: the implication itself, both override directions, Content-Type default/override/suppression, empty `-d`, the untouched no-`-d` path, and — mirroring the explicit `-X POST` cases in the redirect and retry suites — that the implied POST replays its method and body through a 308 and survives a retry.
- Issue 17's flipped test moved out of the known-issues file the same way (now `TestE2EBadPatternIsRejected`), restoring that file to what its header claims: only behaviour that is currently wrong.
- README flag table updated; a curl-parity note added next to the existing `-H` note.

Related:
- https://github.com/korya/http-assert/issues/28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiEcuZhTyL5XbrCwyiHau8