### PR TITLE
Add --assert-jq for JSON responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ A `-H` value needs a colon. A bare name exits `71` rather than being sent as a h
 | `--assert-body` | Assert body matches regex pattern |
 | `--assert-body-eq` | Assert body equals exact value |
 | `--assert-body-empty` | Assert body is empty |
+| `--assert-jq` | Assert a jq expression yields `true` (can be used multiple times) |
 | `--assert-redirect` | Assert redirect location matches regex |
 | `--assert-redirect-eq` | Assert redirect location equals exact value |
 
@@ -104,6 +105,57 @@ http-assert --assert-body-empty=false https://api.example.com/report
 ```
 
 The three body assertions run against the decoded payload, never the bytes on the wire — see [Compression](#compression).
+
+### JSON Assertions
+
+`--assert-jq` runs a [jq](https://jqlang.github.io/jq/) expression against the
+response body and passes when it yields `true`:
+
+```bash
+http-assert --assert-jq '.status == "success"' https://api.example.com/health
+```
+
+**Prefer it over `--assert-body` for JSON.** A regex works on the serialized
+text, so it breaks when the server adds a space, reorders keys or escapes a
+character -- none of which change what the response means:
+
+```bash
+# breaks on {"status": "success"}
+http-assert --assert-body '"status":"success"' https://api.example.com/
+
+# does not care how the JSON is formatted
+http-assert --assert-jq '.status == "success"' https://api.example.com/
+```
+
+**Repeat it to assert several things**, alongside any other assertion. Every
+failure is reported, not just the first:
+
+```bash
+http-assert \
+  --assert-jq '.status == "success"' \
+  --assert-jq '.users | length > 0' \
+  --assert-jq '[.users[].active] | all' \
+  --assert-status 200 \
+  https://api.example.com/users
+```
+
+The expression yields the verdict itself rather than a path and an expected
+value, so jq's types, comparisons, `select`, `length` and `test()` are all
+available and there is no separate syntax to learn. An expression that works in
+`jq` works here.
+
+Three things to know:
+
+- **A query that yields no output fails.** `.users[] | select(.id == 99) | .active`
+  produces nothing when no user has that id, and passing would mean reporting
+  success for a check that examined nothing.
+- **A query must yield `true`, not a value.** `--assert-jq '.status'` fails with
+  `expected true, got "success"`. Write the comparison.
+- **A broken expression exits `71` before the request is made**, so a typo is
+  never mistaken for a service answering wrongly.
+
+A body that is not JSON, is empty, or is still compressed fails the assertion
+saying which, rather than blaming the expression.
 
 ### Redirects
 
@@ -312,7 +364,7 @@ http-assert -X POST \
 http-assert \
   --assert-ok \
   --assert-header-eq "Content-Type: application/json" \
-  --assert-body "\"status\":\"success\"" \
+  --assert-jq '.status == "success"' \
   https://api.example.com/status
 ```
 

--- a/assertions.go
+++ b/assertions.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
+	"time"
+
+	"github.com/itchyny/gojq"
 )
 
 type Assertion func(res *httpResponse) error
@@ -133,6 +138,102 @@ func AssertBodyEmpty() Assertion {
 
 		return nil
 	}
+}
+
+// jqTimeout bounds the evaluation of one --assert-jq query.
+//
+// jq is a real language, so a query can simply never finish: `def f: f; f`
+// compiles cleanly and runs forever. Nothing else a caller can type makes this
+// program hang -- the request is bounded by --max-time, the retry loop by
+// --retry, and an --assert-body pattern cannot blow up because Go's regexp
+// engine is linear-time. This keeps that property rather than trading it away.
+//
+// It is not a budget for real work, and deliberately is not --max-time: that
+// bounds a request, and reusing it here would make a run take twice the number
+// the caller set. Measured queries finish in tens of microseconds, so ten
+// seconds is six orders of magnitude of headroom that no genuine assertion can
+// reach.
+const jqTimeout = 10 * time.Second
+
+// AssertJQ asserts that a jq expression holds against the response body.
+//
+// The expression yields the verdict itself rather than a path and an expected
+// value, which is what keeps this to one flag: jq already has types,
+// comparison and regexp, so there is no separator to invent, no ~= variant,
+// and no question of whether 5 means the number or the string.
+func AssertJQ(query string) (Assertion, error) {
+	q, err := gojq.Parse(query)
+	if err != nil {
+		return nil, err
+	}
+
+	// Compiled as well as parsed, because the two reject different things:
+	// `no_such_func(.)` and `. as $x | $y` are syntactically valid and fail
+	// only here. Catching them now is what makes a typo exit 71 against the
+	// flag rather than 93 in the middle of a run.
+	code, err := gojq.Compile(q)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(res *httpResponse) error {
+		return runJQ(code, query, res, jqTimeout)
+	}, nil
+}
+
+// runJQ evaluates one compiled query. The deadline is a parameter so the test
+// for it need not wait out the real one; every caller passes jqTimeout.
+func runJQ(code *gojq.Code, query string, res *httpResponse, timeout time.Duration) error {
+	doc, err := res.decodeJSON()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	outputs := 0
+	it := code.RunWithContext(ctx, doc)
+	for {
+		v, ok := it.Next()
+		if !ok {
+			break
+		}
+		outputs++
+
+		// gojq reports a runtime failure as an error *value* in the output
+		// stream rather than as a Go error. Untyped it would read as "not
+		// true", turning a broken query into a failed assertion and
+		// sending the reader to inspect a service that answered correctly.
+		if e, isErr := v.(error); isErr {
+			return fmt.Errorf("jq[%s]: %s", query, e)
+		}
+
+		if b, isBool := v.(bool); !isBool || !b {
+			return fmt.Errorf("jq[%s]: expected true, got %s", query, jqValue(v))
+		}
+	}
+
+	// A query that matched nothing checked nothing. Reporting that as a
+	// pass is the one outcome this program exists to refuse, and it is
+	// reachable by accident: `.users[] | select(.id == 99) | .active`
+	// yields no output at all when no user has that id.
+	if outputs == 0 {
+		return fmt.Errorf("jq[%s]: expected true, got no output", query)
+	}
+
+	return nil
+}
+
+// jqValue renders a query's output for the failure message. jq's own notation
+// is JSON, so this is what `jq` would have printed for the same expression.
+func jqValue(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+
+	return string(b)
 }
 
 func AssertBodyNotEmpty() Assertion {

--- a/e2e_config_test.go
+++ b/e2e_config_test.go
@@ -15,7 +15,7 @@ import (
 // the two sources is covered separately by TestE2EConfigPrecedence.
 //
 // EnvSupported records what the tool does *today*, not what it should do. Only
-// 6 of the 24 options honour the environment; the other 18 silently ignore it
+// 6 of the 25 options honour the environment; the other 19 silently ignore it
 // (#54 proposes making this uniform). When that lands, flip those booleans --
 // the diff is the proof the change did what it claimed.
 
@@ -180,6 +180,7 @@ func configCases(t *testing.T) []configCase {
 		assertion("assert-body-empty", []string{"--assert-body-empty"}, "HTTP_ASSERT_ASSERT_BODY_EMPTY", url("/empty")),
 		assertion("assert-redirect", []string{"--assert-redirect", `https://.*\.com/.*`}, "HTTP_ASSERT_ASSERT_REDIRECT", url("/redirect")),
 		assertion("assert-redirect-eq", []string{"--assert-redirect-eq", "https://new-domain.com/path"}, "HTTP_ASSERT_ASSERT_REDIRECT_EQ", url("/redirect")),
+		assertion("assert-jq", []string{"--assert-jq", `.status == "success"`}, "HTTP_ASSERT_ASSERT_JQ", url("/json")),
 	}
 }
 
@@ -187,7 +188,7 @@ func TestE2EConfigContract(t *testing.T) {
 	cases := configCases(t)
 
 	// Guards against an option being added to the CLI and quietly skipped here.
-	if got, want := len(cases), 24; got != want {
+	if got, want := len(cases), 25; got != want {
 		t.Fatalf("config matrix covers %d options, want %d -- add the new flag to configCases", got, want)
 	}
 
@@ -210,7 +211,7 @@ func TestE2EConfigContract(t *testing.T) {
 			t.Run("env", func(t *testing.T) {
 				if !tc.EnvSupported {
 					characterizes(t, tc.Issue,
-						tc.EnvKey+" is ignored; only 6 of 24 options read the environment")
+						tc.EnvKey+" is ignored; only 6 of 25 options read the environment")
 				}
 				r := run(t, map[string]string{tc.EnvKey: tc.EnvVal}, tc.Base...)
 				if got := tc.Applied(r); got != tc.EnvSupported {

--- a/e2e_jq_test.go
+++ b/e2e_jq_test.go
@@ -1,0 +1,199 @@
+package main_test
+
+import "testing"
+
+// --assert-jq is the answer to asserting on JSON with a regex, which breaks on
+// whitespace, key order and escaping. jq yields the verdict itself, so there is
+// no path-and-value syntax to invent and no question of whether 5 means the
+// number or the string.
+
+func TestE2EAssertJQ(t *testing.T) {
+	t.Run("a query that holds", func(t *testing.T) {
+		assertExit(t, run(t, nil, "--assert-jq", `.status == "success"`, url("/json")), exitOK)
+	})
+
+	t.Run("a query that does not", func(t *testing.T) {
+		r := run(t, nil, "--assert-jq", `.status == "nope"`, url("/json"))
+		assertExit(t, r, exitRequestFail)
+		// The failure names the query, because a run can carry several.
+		assertContains(t, r, `jq[.status == "nope"]: expected true, got false`)
+	})
+
+	// What regex over JSON cannot do, and the reason this exists.
+	t.Run("it reads structure, not text", func(t *testing.T) {
+		for _, q := range []string{
+			`.users | length == 2`,
+			`.meta.version == "v1"`,
+			`.count == 2`,
+			`.active`,
+			`[.users[].name] == ["alice","bob"]`,
+			`.users | map(select(.active)) | length == 2`,
+			`.status | test("^suc")`,
+		} {
+			t.Run(q, func(t *testing.T) {
+				assertExit(t, run(t, nil, "--assert-jq", q, url("/json")), exitOK)
+			})
+		}
+	})
+}
+
+// TestE2EAssertJQAccumulates: repeating the flag adds assertions rather than
+// replacing them, as it does for the three header assertions. --assert-jq is a
+// string array, so rejectRepeats leaves it alone.
+func TestE2EAssertJQAccumulates(t *testing.T) {
+	t.Run("every query is checked", func(t *testing.T) {
+		assertExit(t, run(t, nil,
+			"--assert-jq", `.status == "success"`,
+			"--assert-jq", `.count == 2`,
+			"--assert-jq", `.users | length == 2`,
+			url("/json")), exitOK)
+	})
+
+	// The failure mode worth pinning: an earlier query passing must not carry
+	// a later one that fails.
+	t.Run("a later query still fails the run", func(t *testing.T) {
+		r := run(t, nil,
+			"--assert-jq", `.status == "success"`,
+			"--assert-jq", `.count == 99`,
+			url("/json"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, `jq[.count == 99]`)
+	})
+
+	t.Run("and an earlier one does too", func(t *testing.T) {
+		r := run(t, nil,
+			"--assert-jq", `.count == 99`,
+			"--assert-jq", `.status == "success"`,
+			url("/json"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, `jq[.count == 99]`)
+	})
+
+	// Every failure is reported, not just the first -- the property that
+	// separates this tool from `curl && jq`.
+	t.Run("several failures are all reported", func(t *testing.T) {
+		r := run(t, nil,
+			"--assert-jq", `.count == 98`,
+			"--assert-jq", `.count == 99`,
+			url("/json"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "2 assertions failed:")
+		assertContains(t, r, `jq[.count == 98]`)
+		assertContains(t, r, `jq[.count == 99]`)
+	})
+}
+
+// TestE2EAssertJQComposes: the other body assertions keep working alongside it,
+// and all of them accumulate into the same run.
+func TestE2EAssertJQComposes(t *testing.T) {
+	t.Run("with every other kind of assertion", func(t *testing.T) {
+		assertExit(t, run(t, nil,
+			"--assert-jq", `.status == "success"`,
+			"--assert-jq", `.users | length == 2`,
+			"--assert-body", `"alice"`,
+			"--assert-body-empty=false",
+			"--assert-status", "200",
+			"--assert-ok",
+			"--assert-header-eq", "Content-Type: application/json",
+			url("/json")), exitOK)
+	})
+
+	// Mixed failures aggregate across kinds, not just within one kind.
+	t.Run("failures aggregate across kinds", func(t *testing.T) {
+		r := run(t, nil,
+			"--assert-jq", `.status == "nope"`,
+			"--assert-body", "never-matches",
+			"--assert-status", "999",
+			url("/json"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "3 assertions failed:")
+		assertContains(t, r, "jq[")
+		assertContains(t, r, "body: expected to match")
+		assertContains(t, r, "status: expected 999")
+	})
+
+	// --assert-body-eq is exact-match over the raw text and must be unaffected
+	// by anything jq does to the decoded document.
+	t.Run("--assert-body-eq still sees the raw text", func(t *testing.T) {
+		assertExit(t, run(t, nil,
+			"--assert-jq", `.count == 2`,
+			"--assert-body-eq", `{"status":"success","count":2}`,
+			url("/json-gzip")), exitOK)
+	})
+
+	// jq reads the decoded payload, like every other body assertion (#27).
+	t.Run("it runs against a decompressed body", func(t *testing.T) {
+		assertExit(t, run(t, nil, "--assert-jq", `.status == "success"`,
+			url("/json-gzip")), exitOK)
+	})
+}
+
+// TestE2EAssertJQRejectsBadQueries: a broken expression is a broken command
+// line, so it is refused before the request is made rather than reported as a
+// failed assertion afterwards.
+func TestE2EAssertJQRejectsBadQueries(t *testing.T) {
+	for _, tc := range []struct {
+		Name  string
+		Query string
+		Diag  string
+	}{
+		{"unterminated", `.users[`, "unexpected EOF"},
+		{"a dangling pipe", `.a |`, "unexpected EOF"},
+		// Parses cleanly and fails only on compile, which is why both stages
+		// run at flag time.
+		{"an undefined function", `nope(.)`, "function not defined: nope/1"},
+		{"an undefined variable", `. as $x | $y`, "variable not defined: $y"},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			r := run(t, nil, "--assert-jq", tc.Query, url("/json"))
+			assertExit(t, r, exitBadFlagVal)
+			assertContains(t, r, "Invalid value for --assert-jq flag")
+			assertContains(t, r, tc.Diag)
+		})
+	}
+
+	// Refused before the request, so a bad query cannot be mistaken for a
+	// service that answered wrongly.
+	t.Run("the request is never made", func(t *testing.T) {
+		r := run(t, nil, "--assert-jq", `.users[`, url("/json"))
+		assertNotContains(t, r, "[:] HTTP")
+	})
+}
+
+// TestE2EAssertJQBodyProblems covers the responses a query cannot be run
+// against at all. Each says the body is at fault rather than the expression.
+func TestE2EAssertJQBodyProblems(t *testing.T) {
+	t.Run("a body that is not JSON", func(t *testing.T) {
+		r := run(t, nil, "--assert-jq", `. == 1`, url("/created"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "body: expected JSON")
+	})
+
+	t.Run("an empty body", func(t *testing.T) {
+		r := run(t, nil, "--assert-jq", `. == 1`, url("/empty"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "body: expected JSON")
+	})
+
+	// An encoding nothing can decode reports the encoding, not invalid JSON.
+	t.Run("a body still encoded", func(t *testing.T) {
+		r := run(t, nil, "--assert-jq", `. == 1`, url("/brotli"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "body: response is br-encoded")
+	})
+
+	// A query yielding nothing has checked nothing, so it must not pass.
+	t.Run("a query that matches nothing", func(t *testing.T) {
+		r := run(t, nil, "--assert-jq", `.users[] | select(.id == 99) | .active`, url("/json"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, "expected true, got no output")
+	})
+
+	// A non-boolean result is a mis-written assertion, and the failure shows
+	// what the query actually produced so the reader can see why.
+	t.Run("a query that yields a value rather than a verdict", func(t *testing.T) {
+		r := run(t, nil, "--assert-jq", `.status`, url("/json"))
+		assertExit(t, r, exitRequestFail)
+		assertContains(t, r, `expected true, got "success"`)
+	})
+}

--- a/e2e_server_test.go
+++ b/e2e_server_test.go
@@ -166,6 +166,22 @@ func testHandler() http.Handler {
 		_ = conn.Close()
 	})
 
+	// A document with enough shape for jq to work on: an array to iterate, a
+	// nested object, and the three scalar types.
+	mux.HandleFunc("/json", func(w http.ResponseWriter, _ *http.Request) {
+		write(w, http.StatusOK, []byte(`{"status":"success","count":2,"active":true,`+
+			`"meta":{"version":"v1"},`+
+			`"users":[{"id":1,"name":"alice","active":true},`+
+			`{"id":2,"name":"bob","active":true}]}`),
+			http.Header{"Content-Type": {"application/json"}})
+	})
+
+	// Valid JSON served gzipped, so a jq assertion can be shown to run against
+	// the decoded payload rather than the bytes on the wire.
+	mux.HandleFunc("/json-gzip", func(w http.ResponseWriter, _ *http.Request) {
+		writeGzip(w, []byte(`{"status":"success","count":2}`))
+	})
+
 	// Two values under one header name, for the multi-value matching path.
 	mux.HandleFunc("/multi", func(w http.ResponseWriter, _ *http.Request) {
 		write(w, http.StatusOK, []byte("ok"), http.Header{"Set-Cookie": {"a=1", "b=2"}})

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,12 @@ module github.com/korya/http-assert
 go 1.25.5
 
 require (
+	github.com/itchyny/gojq v0.12.19
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 )
 
-require github.com/inconshreveable/mousetrap v1.1.0 // indirect
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/itchyny/timefmt-go v0.1.8 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/itchyny/gojq v0.12.19 h1:ttXA0XCLEMoaLOz5lSeFOZ6u6Q3QxmG46vfgI4O0DEs=
+github.com/itchyny/gojq v0.12.19/go.mod h1:5galtVPDywX8SPSOrqjGxkBeDhSxEW1gSxoy7tn1iZY=
+github.com/itchyny/timefmt-go v0.1.8 h1:1YEo1JvfXeAHKdjelbYr/uCuhkybaHCeTkH8Bo791OI=
+github.com/itchyny/timefmt-go v0.1.8/go.mod h1:5E46Q+zj7vbTgWY8o5YkMeYb4I6GeWLFnetPy5oBrAI=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=

--- a/jq_test.go
+++ b/jq_test.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/itchyny/gojq"
+)
+
+const jqDoc = `{"status":"success","count":5,"active":true,"nothing":null,
+ "users":[{"id":1,"name":"alice","active":true},{"id":2,"name":"bob","active":false}]}`
+
+// jqResponse builds a response carrying the document above, or whatever body a
+// case needs.
+func jqResponse(body string) *httpResponse {
+	r := response("200 OK", http.Header{}, "")
+	r.BodyBytes = []byte(body)
+
+	return &r
+}
+
+// Test_AssertJQ is the verdict table: what a query must yield for the assertion
+// to hold, and what the failure says when it does not.
+func Test_AssertJQ(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Name  string
+		Query string
+		Body  string
+		// Want is the expected error text, empty for a passing assertion.
+		Want string
+	}{
+		{Name: "a true comparison", Query: `.status == "success"`, Body: jqDoc},
+		{Name: "a numeric comparison", Query: `.count == 5`, Body: jqDoc},
+		{Name: "a boolean field read directly", Query: `.active`, Body: jqDoc},
+		{Name: "a builtin", Query: `.users | length == 2`, Body: jqDoc},
+		{Name: "a regexp, which jq has of its own", Query: `.status | test("^suc")`, Body: jqDoc},
+		{
+			// Several outputs, all true. Every one has to hold, or the
+			// assertion would pass on the strength of the first.
+			Name:  "every output true",
+			Query: `.users[] | .id > 0`,
+			Body:  jqDoc,
+		},
+		{
+			Name:  "one output false among several",
+			Query: `.users[] | .active`,
+			Body:  jqDoc,
+			Want:  `jq[.users[] | .active]: expected true, got false`,
+		},
+		{
+			// The case that makes this more than a nicety: a query matching
+			// nothing has checked nothing, and a pass would be a green run
+			// with no check behind it.
+			Name:  "no output at all",
+			Query: `.users[] | select(.id == 99) | .active`,
+			Body:  jqDoc,
+			Want:  `jq[.users[] | select(.id == 99) | .active]: expected true, got no output`,
+		},
+		{
+			Name:  "a non-boolean output",
+			Query: `.status`,
+			Body:  jqDoc,
+			Want:  `jq[.status]: expected true, got "success"`,
+		},
+		{
+			// A missing key yields null rather than an error, so without this
+			// the failure would read as an unhelpful "got <nil>".
+			Name:  "a missing key",
+			Query: `.nope`,
+			Body:  jqDoc,
+			Want:  `jq[.nope]: expected true, got null`,
+		},
+		{
+			Name:  "a JSON null field",
+			Query: `.nothing`,
+			Body:  jqDoc,
+			Want:  `jq[.nothing]: expected true, got null`,
+		},
+		{
+			// Reported as a broken query, not as a failed assertion. The
+			// service answered correctly; the expression is what is wrong.
+			Name:  "a runtime type error",
+			Query: `.status + 1`,
+			Body:  jqDoc,
+			Want:  `jq[.status + 1]: cannot add: string ("success") and number (1)`,
+		},
+		{
+			Name:  "an object output",
+			Query: `.users[0]`,
+			Body:  jqDoc,
+			Want:  `jq[.users[0]]: expected true, got {"active":true,"id":1,"name":"alice"}`,
+		},
+		{
+			Name:  "a body that is not JSON",
+			Query: `. == 1`,
+			Body:  "plain text",
+			Want:  "body: expected JSON, got invalid character 'p' looking for beginning of value",
+		},
+		{
+			// A 204 has no body to decode. The message names the body rather
+			// than blaming the expression.
+			Name:  "an empty body",
+			Query: `. == 1`,
+			Body:  "",
+			Want:  "body: expected JSON, got unexpected end of JSON input",
+		},
+		{
+			// Valid JSON that is not an object. jq is happy; so is this.
+			Name:  "a top-level array",
+			Query: `length == 3`,
+			Body:  `[1,2,3]`,
+		},
+		{
+			Name:  "a top-level scalar",
+			Query: `. == 42`,
+			Body:  `42`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			a, err := AssertJQ(tc.Query)
+			if err != nil {
+				t.Fatalf("cannot build the assertion: %s", err)
+			}
+
+			checkErr(t, "jq", a(jqResponse(tc.Body)), tc.Want)
+		})
+	}
+}
+
+// Test_AssertJQ_rejectsBadQueries covers the two ways a query can be invalid.
+// They are caught at different stages, and only catching one would let a typo
+// reach the response and be reported as a failed assertion.
+func Test_AssertJQ_rejectsBadQueries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Name  string
+		Query string
+		Want  string
+		Why   string
+	}{
+		{"unterminated", `.users[`, "unexpected EOF", "rejected while parsing"},
+		{"a dangling pipe", `.a |`, "unexpected EOF", "rejected while parsing"},
+		{
+			// Parses cleanly; only compiling notices. This is why both stages
+			// run before the request is made.
+			Name: "an undefined function", Query: `nope(.)`,
+			Want: "function not defined: nope/1", Why: "rejected while compiling",
+		},
+		{
+			Name: "an undefined variable", Query: `. as $x | $y`,
+			Want: "variable not defined: $y", Why: "rejected while compiling",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			a, err := AssertJQ(tc.Query)
+			if err == nil {
+				t.Fatalf("%q was accepted; expected it to be %s", tc.Query, tc.Why)
+			}
+			if a != nil {
+				t.Error("expected a nil Assertion alongside the error")
+			}
+			if got := err.Error(); !strings.Contains(got, tc.Want) {
+				t.Errorf("error = %q, want it to contain %q", got, tc.Want)
+			}
+		})
+	}
+}
+
+// Test_AssertJQ_boundsARunawayQuery: jq is a real language, so a query can
+// simply never finish. Nothing else a caller can type makes this program hang
+// -- the request is bounded by --max-time, the retry loop by --retry, and an
+// --assert-body pattern cannot blow up because Go's regexp engine is
+// linear-time. This is what keeps that true.
+//
+// Driven through runJQ with a short deadline rather than through the assertion
+// with the real one: waiting out 10s twice would add 20s to a unit suite that
+// otherwise runs in a quarter of a second, on every one of CI's six legs.
+func Test_AssertJQ_boundsARunawayQuery(t *testing.T) {
+	t.Parallel()
+
+	const short = 50 * time.Millisecond
+
+	// Both compile cleanly. They are valid jq rather than malformed input, so
+	// no amount of validation at flag time could catch them -- which is why the
+	// bound has to exist at all.
+	for _, query := range []string{`def f: f; f`, `reduce range(1e9) as $i (0; .+$i)`} {
+		t.Run(query, func(t *testing.T) {
+			q, err := gojq.Parse(query)
+			if err != nil {
+				t.Fatalf("expected %q to parse: %s", query, err)
+			}
+			code, err := gojq.Compile(q)
+			if err != nil {
+				t.Fatalf("expected %q to compile: %s", query, err)
+			}
+
+			done := make(chan error, 1)
+			start := time.Now()
+			go func() { done <- runJQ(code, query, jqResponse(jqDoc), short) }()
+
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Fatal("a non-terminating query reported success")
+				}
+				// Stopping early would mean it never really ran, so the
+				// deadline is asserted from both sides.
+				if d := time.Since(start); d < short {
+					t.Errorf("stopped after %v, before the %v deadline: %s", d, short, err)
+				}
+			case <-time.After(30 * time.Second):
+				t.Fatal("still running long past the deadline")
+			}
+		})
+	}
+}
+
+// Test_jqTimeout pins the deadline the assertion actually uses. The test above
+// injects its own, so without this the real value could drift to something
+// useless and nothing would notice.
+func Test_jqTimeout(t *testing.T) {
+	t.Parallel()
+
+	if got, want := jqTimeout, 10*time.Second; got != want {
+		t.Errorf("jqTimeout = %v, want %v", got, want)
+	}
+}
+
+// Test_decodeJSON_parsesOnce pins the sharing. Ten --assert-jq flags read one
+// response, and it should be decoded once rather than ten times.
+func Test_decodeJSON_parsesOnce(t *testing.T) {
+	t.Parallel()
+
+	res := jqResponse(jqDoc)
+
+	first, err := res.decodeJSON()
+	if err != nil {
+		t.Fatalf("first decode: %s", err)
+	}
+	second, err := res.decodeJSON()
+	if err != nil {
+		t.Fatalf("second decode: %s", err)
+	}
+
+	// Same map, not an equal one: a second Unmarshal would produce a distinct
+	// value, so identity is what proves the body was parsed once.
+	m1, ok1 := first.(map[string]any)
+	m2, ok2 := second.(map[string]any)
+	if !ok1 || !ok2 {
+		t.Fatalf("expected a JSON object, got %T and %T", first, second)
+	}
+	m1["probe"] = true
+	if _, carried := m2["probe"]; !carried {
+		t.Error("decodeJSON re-parsed the body instead of sharing the first result")
+	}
+
+	t.Run("a failure is remembered too", func(t *testing.T) {
+		bad := jqResponse("not json")
+		if _, err := bad.decodeJSON(); err == nil {
+			t.Fatal("expected an error")
+		}
+		if _, err := bad.decodeJSON(); err == nil {
+			t.Error("the second call lost the error the first recorded")
+		}
+	})
+
+	// A body that is still compressed must report that, not invalid JSON --
+	// the reader would otherwise go looking for a malformed payload (#27).
+	t.Run("an undecoded body reports the encoding", func(t *testing.T) {
+		enc := jqResponse(jqDoc)
+		enc.Encoding = "br"
+		enc.DecodeErr = errors.New("no decoder for \"br\"")
+
+		_, err := enc.decodeJSON()
+		checkErrMatch(t, "decodeJSON", err, `^body: response is br-encoded`)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,11 @@
 // The two boolean assertions negate with =false, which selects the opposite
 // assertion rather than cancelling the flag.
 //
+// --assert-jq asserts a jq expression against a JSON body, and repeats like the
+// header assertions do. The expression yields the verdict itself, so there is
+// no path-and-value syntax and no question of whether 5 means the number or the
+// string -- jq already has types, comparison and regexp.
+//
 //	http-assert --assert-ok https://example.com
 //	http-assert --assert-status 201 -X POST -d '{"n":1}' https://api.example.com/things
 //	http-assert --assert-header 'Content-Type: application/json' \
@@ -90,6 +95,7 @@ import (
 	"compress/zlib"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -131,6 +137,10 @@ The two boolean assertions can be negated with =false, which selects the
 opposite assertion rather than cancelling the flag: --assert-ok=false asserts
 the status IS an error, and --assert-body-empty=false asserts the body is not
 empty.
+
+Repeat --assert-jq to assert several jq expressions against a JSON body. Each
+must yield true; a query that yields nothing has checked nothing and fails.
+A query is compiled before the request is made, so a broken one exits 71.
 
 Exit codes:
   0    every assertion passed
@@ -529,6 +539,8 @@ func registerAssertionFlags(cmd *cobra.Command) {
 	cmd.Flags().String("assert-body-eq", "", "Assert body equals the provided value")
 	cmd.Flags().Bool("assert-body-empty", false,
 		"Assert body is empty; =false asserts it is not")
+	cmd.Flags().StringArray("assert-jq", nil,
+		"Assert the jq expression yields true; repeat to assert several")
 
 	// Common shorthands
 	cmd.Flags().Bool("assert-ok", false,
@@ -671,6 +683,17 @@ func parseAssertionFlags(cmd *cobra.Command) []Assertion {
 		v, _ := cmd.Flags().GetString("assert-body-eq")
 		res = append(res, AssertBodyEqual(v))
 	}
+
+	// One assertion per occurrence. --assert-jq is a stringArray, so rejectRepeats
+	// leaves it alone and repeating it accumulates, exactly as it does for the
+	// three header assertions.
+	if cmd.Flags().Changed("assert-jq") {
+		vs, _ := cmd.Flags().GetStringArray("assert-jq")
+		for _, v := range vs {
+			res = append(res, mustCompileAssertion("--assert-jq", v, AssertJQ))
+		}
+	}
+
 	return res
 }
 
@@ -1046,6 +1069,41 @@ type httpResponse struct {
 	// DecodeErr is why BodyBytes is still encoded. Nil means BodyBytes is the
 	// payload, whether or not anything had to be removed to get there.
 	DecodeErr error
+	// The decoded JSON body, filled by decodeJSON on first use. Plain fields
+	// rather than a sync.Once because httpResponse is passed around by value in
+	// places, and a value copy of a mutex is what go vet exists to catch.
+	jsonBody   any
+	jsonErr    error
+	jsonParsed bool
+}
+
+// decodeJSON decodes the body as JSON once and shares the result.
+//
+// Every --assert-jq in a run reads the same response, so ten queries should
+// parse it once rather than ten times. Failure is reported as a property of the
+// body, not of the query: a response that is not JSON fails every jq assertion
+// for the same reason, and saying so once per assertion is clearer than saying
+// the expression did not hold.
+func (r *httpResponse) decodeJSON() (any, error) {
+	if r.jsonParsed {
+		return r.jsonBody, r.jsonErr
+	}
+	r.jsonParsed = true
+
+	// Through bodyOf like every other body assertion, so a body that is still
+	// compressed reports that rather than reporting invalid JSON (#27).
+	body, err := bodyOf(r)
+	if err != nil {
+		r.jsonErr = err
+		return nil, r.jsonErr
+	}
+
+	if err := json.Unmarshal(body, &r.jsonBody); err != nil {
+		r.jsonErr = fmt.Errorf("body: expected JSON, got %s", err)
+		return nil, r.jsonErr
+	}
+
+	return r.jsonBody, nil
 }
 
 // decoders maps a Content-Encoding to something that removes it. Content


### PR DESCRIPTION
## Problem

Asserting on a JSON body meant writing a regex over the serialized text, which breaks on anything that changes the bytes without changing the meaning.

The README recommended exactly that, and its own example was brittle — verified against this repo's test server:

| Pattern | vs `{"status":"success"}` | vs the same document pretty-printed |
|---|---|---|
| `"status":"success"` | exit 0 | **exit 93** |

A space after a colon is enough. So are a different key order and an escaped character. None of them change what the response says.

## Solution

`--assert-jq` runs a jq expression and passes when it yields `true`:

```console
$ http-assert --assert-jq '.status == "success"' https://api.example.com/health
[+] PASSED 41ms
```

**The expression yields the verdict itself**, rather than taking a path and an expected value. That is what keeps this to one flag. The alternative in the issue — `--assert-json '$.status=success'` — needs a separator rule, a `~=` variant for regex, and a decision about whether `5` means the number or the string. jq already has types, comparison, `select`, `length` and `test()`, so all three questions disappear, and an expression that works in `jq` works here.

**Repeating accumulates**, as it does for the header assertions, and it composes with everything else. All failures are still reported together:

```
Error: Cannot perform request: 4 assertions failed:
- status: expected 999, got 200 ("200 OK")
- body: expected to match "never-matches", got "{\"status\":\"success\"…"
- jq[.count == 99]: expected true, got false
- jq[.status]: expected true, got "success"
```

`--assert-jq` is a string array, so `rejectRepeats` leaves it alone and repetition accumulates without a special case.

### Three refusals

Each would otherwise be a run that checked less than it claimed — the failure mode of #35, #27 and #22.

| Case | Result | Why not the alternative |
|---|---|---|
| A query yielding **no output** | fails | `.users[] \| select(.id == 99) \| .active` produces nothing when no user has that id. Passing would report success for a check that examined nothing. |
| A query yielding **a value, not a verdict** | fails, showing the value | `--assert-jq '.status'` says `expected true, got "success"`. Treating a truthy value as a pass would make `.count` pass on any non-zero count. |
| A query that **will not compile** | exit `71`, before the request | Both `Parse` and `Compile` run: `nope(.)` and `. as $x \| $y` are syntactically valid and fail only at the second. Catching them at flag time is what stops a typo being reported as a service answering wrongly. |

A runtime error is reported as a broken query rather than a failed assertion — gojq returns those as an error *value* in the output stream, and left untyped it would read as "not true" and send the reader to inspect a service that answered correctly.

### Evaluation is bounded at ten seconds

jq is a real language, so a query can simply never finish. `def f: f; f` and `reduce range(1e9) as $i (0; .+$i)` both compile cleanly — they are valid jq, so no amount of flag-time validation catches them.

Today nothing a caller can type makes this tool hang: the request is bounded by `--max-time`, the retry loop by `--retry`, and an `--assert-body` pattern cannot blow up because Go's regexp engine is linear-time. gojq would be the first exception, and the bound keeps that property.

Deliberately **not** `--max-time`: that bounds a request, and reusing it for post-response work would make a run take up to twice the number the caller set. Real queries finish in tens of microseconds, so ten seconds is six orders of magnitude of headroom.

### Cost

One direct dependency and 1.1 MB:

| | before | after |
|---|---|---|
| `go.mod` requires | 3 | 4 (`gojq`, plus `timefmt-go` indirect) |
| packages in build | 196 | 199 |
| stripped binary | 6.26 MB | 7.38 MB |

Smaller than the estimate this was approved on — nine modules appear in gojq's own graph, but only two reach a build that imports the library.

## Other Changes

The body is decoded once per response and shared, so ten queries parse it once rather than ten times. Decoding goes through `bodyOf` like every other body assertion, so a body that is still compressed reports the encoding rather than reporting invalid JSON (#27).

The README's brittle "Multiple Assertions" example now uses `--assert-jq`, since it was the example the issue cited.

Test coverage: the verdict table (multi-output, zero-output, non-boolean, null, missing key, runtime error, non-JSON, empty body, top-level array and scalar); both rejection stages; accumulation in both orders plus aggregation across assertion kinds; composition with `--assert-body`, `--assert-body-eq`, `--assert-status`, `--assert-ok` and `--assert-header-eq`; and jq running against a gzipped body.

The runaway-query test drives `runJQ` with a 50ms deadline rather than the assertion with the real one — waiting out 10s twice would have added 20s to a unit suite that otherwise runs in under half a second, on each of CI's six legs. A separate test pins the real constant so it cannot drift unnoticed.

The config matrix guard moves 24 → 25.

There are no screenshots because there is no rendered UI; this tool's user-visible surface is terminal output, shown inline above.

Closes #43

Related:
- https://github.com/korya/http-assert/issues/45 — `--json` output; the decoded body this adds is what that would serialize
- https://github.com/korya/http-assert/issues/34 — stdout is always empty, so piping a body to real `jq` is not currently possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EMMhgmTkbzAsmeNy97PrP
