### PR TITLE
Rebuild the README: correct it, complete it, and put readers first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,78 @@
-# http-assert ![Github Actions](https://github.com/korya/http-assert/actions/workflows/build.yml/badge.svg) [![Go Reference](https://pkg.go.dev/badge/github.com/korya/http-assert.svg)](https://pkg.go.dev/github.com/korya/http-assert)
+# http-assert ![Github Actions](https://github.com/korya/http-assert/actions/workflows/build.yml/badge.svg)
 
-A command-line tool for performing HTTP requests and asserting properties of the response. This tool is designed for testing HTTP endpoints, health checks, monitoring, and CI/CD pipelines.
+Make an HTTP request, assert on what comes back, exit non-zero when it's wrong.
 
-## Purpose
+```console
+$ http-assert --retry 30 --retry-delay 1s \
+    --assert-status 200 \
+    --assert-jq '.status == "healthy"' \
+    https://api.example.com/health
+[.] HTTP/1.1 GET https://api.example.com/health
+[:] HTTP/1.1 503 Service Unavailable
+[-] FAILED 12ms
 
-`http-assert` combines the functionality of making HTTP requests with the ability to validate responses against multiple criteria. It's particularly useful for:
+[~] retry 1/30 in 1s
+[.] HTTP/1.1 GET https://api.example.com/health
+[:] HTTP/1.1 200 OK
+[+] PASSED 9ms
+```
 
-- **Health checks and monitoring**: Verify that your APIs are returning expected responses
-- **CI/CD pipelines**: Validate deployed services before proceeding with deployment
-- **Integration testing**: Test HTTP endpoints with various assertion conditions
-- **Load balancer testing**: Use host mapping to test different backend servers
-- **Self-signed and internal endpoints**: `--insecure` reaches hosts that cannot present a verifiable certificate
+Each line is prefixed with a sigil: `[.]` request sent, `[>]` redirect
+followed, `[:]` response received, `[~]` waiting to retry, and `[+]`/`[-]` for
+the verdict. The exit code is the result.
+
+## Why
+
+Every pipeline has a step shaped like "deploy, then ask: is it actually up?"
+The stock answers each see half the picture:
+
+- **`curl -f`** checks the status code and nothing else. A health endpoint
+  answering `200` with `{"status":"degraded"}` passes.
+- **`curl -s … | jq -e`** checks the body and nothing else. A `503` whose body
+  still says `{"status":"ok"}` passes, because `jq` never sees the status code.
+- **Chaining both** closes those holes and opens others: the only diagnostic is
+  a bare exit code, nothing retries while the service comes up, and the
+  healthcheck image now needs `curl` *and* `jq` in it.
+
+`http-assert` is the missing middle: one static binary that makes the request,
+checks status, headers and body in a single pass, retries until the service is
+ready, and — when the check fails — reports every failing assertion with what
+it actually saw:
+
+```console
+$ http-assert --assert-status 200 --assert-jq '.status == "healthy"' https://api.example.com/health
+
+Error: Cannot perform request: 2 assertions failed:
+- status: expected 200, got 503 ("503 Service Unavailable")
+- jq[.status == "healthy"]: expected true, got "degraded"
+```
+
+Built for the places where the exit code is the whole point:
+
+- **Deploy gates** — replace `sleep 10; curl -f` with a poll that passes the
+  moment the service is ready and fails with evidence when it never is
+- **Container healthchecks** — statically linked, drops into a `scratch` or
+  `distroless` image with `COPY --from`
+- **Monitoring probes** — aggregated failure reports that read well in a CI
+  log, no ANSI codes
+- **Backend verification** — `--maphost` aims the same request at a specific
+  backend behind a load balancer
+
+The flags follow `curl` where that helps; where a checking tool needs a
+different answer, the deviation is deliberate and documented — see
+[Coming from curl](#coming-from-curl).
+
+## Contents
+
+- [Installation](#installation)
+- [Usage](#usage): [request options](#request-options),
+  [assertions](#assertion-options), [JSON](#json-assertions),
+  [redirects](#redirects), [retries](#retries), [compression](#compression),
+  [logging](#logging-options)
+- [Recipes](#recipes)
+- [Reference](#reference): [environment variables](#environment-variables),
+  [exit codes](#exit-codes), [coming from curl](#coming-from-curl)
+- [License](#license) · [Development](#development)
 
 ## Installation
 
@@ -49,14 +111,6 @@ http-assert completion zsh --help   # per-shell install instructions
 
 ```bash
 go install github.com/korya/http-assert@latest
-```
-
-### Build from Repository
-
-```bash
-git clone https://github.com/korya/http-assert.git
-cd http-assert
-go build -o http-assert .
 ```
 
 ## Usage
@@ -338,10 +392,6 @@ way. Reading those bytes as plain text would be its own silent corruption.
 **Everything the tool prints goes to stderr; stdout is always empty.** Use
 `2>&1` when capturing output in a file or a pipe.
 
-Each log line is prefixed with a sigil: `[.]` request sent, `[>]` redirect
-followed, `[:]` response received, `[~]` waiting to retry, and `[+]`/`[-]` for
-the verdict.
-
 `warn` is accepted but currently logs exactly what `error` does; nothing in the
 tool logs at the warn level.
 
@@ -360,59 +410,56 @@ http-assert version v0.1.0 (commit 4ffe282, built 2026-08-07T22:24:59Z, go1.25.5
 A binary built from a checkout rather than a release reports the commit it was
 built from instead of a tag.
 
-## Examples
+## Recipes
 
-### Basic Health Check
-
-```bash
-# Simple health check - assert 200 OK
-http-assert --assert-ok https://api.example.com/health
-```
-
-### POST Request with JSON Body
+### Deploy Gate
 
 ```bash
-# POST with JSON data; -d implies POST
+#!/bin/bash
+# Deploy and validate service
+deploy-service.sh
+
+# Wait for the service to come up, then validate the deployment. Retrying
+# replaces a fixed `sleep`: it returns as soon as the service is ready instead
+# of always waiting for the worst case, and it does not give up early when the
+# worst case is exceeded.
 http-assert \
-  -H "Content-Type: application/json" \
-  -d '{"username":"test","password":"secret"}' \
-  --assert-status 201 \
-  https://api.example.com/login
-```
-
-### Multiple Assertions
-
-```bash
-# Multiple assertions on the same request
-http-assert \
+  --max-time 30 \
+  --retry 30 --retry-delay 1s \
   --assert-ok \
-  --assert-header-eq "Content-Type: application/json" \
-  --assert-jq '.status == "success"' \
-  https://api.example.com/status
+  --assert-header-eq "X-Service-Version: $EXPECTED_VERSION" \
+  https://api.example.com/health
+
+if [ $? -eq 0 ]; then
+  echo "Deployment validation passed"
+else
+  echo "Deployment validation failed"
+  exit 1
+fi
 ```
 
-### Header Validation
+### Monitoring Script
 
 ```bash
-# Assert specific headers are present and have expected values
-http-assert \
-  --assert-header-eq "X-API-Version: v1" \
-  --assert-header-missing "X-Debug-Info" \
-  --assert-header "Cache-Control: max-age=\d+" \
-  https://api.example.com/data
+#!/bin/bash
+# Simple monitoring script
+ENDPOINTS=(
+  "https://api.example.com/health"
+  "https://db.example.com/ping"
+  "https://cache.example.com/status"
+)
+
+for endpoint in "${ENDPOINTS[@]}"; do
+  # Two retries so a single blip does not page anyone at 3am.
+  if http-assert --silent --retry 2 --retry-delay 5s --assert-ok "$endpoint"; then
+    echo "✓ $endpoint"
+  else
+    echo "✗ $endpoint"
+  fi
+done
 ```
 
-### SSL and Security Testing
-
-```bash
-# Test with SSL verification disabled
-http-assert --insecure --assert-ok https://self-signed.example.com
-
-# Test with custom timeout
-http-assert --max-time 5 --assert-ok https://slow-api.example.com
-```
-
-### Host Mapping for Load Balancer Testing
+### Checking Backends Behind a Load Balancer
 
 ```bash
 # Map requests to specific backend servers
@@ -428,67 +475,44 @@ http-assert \
   http://loadbalancer.example.com
 ```
 
-### Redirect Testing
 
 ```bash
-# Assert redirect to specific URL
-http-assert \
-  --assert-redirect-eq "https://new-domain.com/path" \
-  https://old-domain.com/path
+# Test all backend servers through load balancer
+BACKENDS=("backend1.internal" "backend2.internal" "backend3.internal")
 
-# Assert redirect matches pattern
-http-assert \
-  --assert-redirect "https://.*\.example\.com/.*" \
-  https://redirect.example.com
-
-# Note: URLs with query parameters should be quoted to avoid shell interpretation
-http-assert \
-  --assert-redirect-eq "https://example.com/target" \
-  "https://example.com/redirect?url=https://example.com/target"
-
-# Follow the chain instead, and assert on where it lands
-http-assert -L \
-  --assert-status 200 \
-  --assert-body '"status":\s*"ok"' \
-  https://old-domain.com/health
-
-# Cap the chain; exceeding the cap fails the run
-http-assert -L --max-redirs 2 --assert-ok https://old-domain.com/health
+for backend in "${BACKENDS[@]}"; do
+  echo "Testing $backend..."
+  http-assert \
+    --maphost "api.example.com:443=$backend:8443" \
+    --assert-ok \
+    --assert-header "X-Backend-Server: $backend" \
+    https://api.example.com/health
+done
 ```
 
-### Waiting for a Service to Become Healthy
+### POST with a JSON Body
 
 ```bash
-# Poll once a second for half a minute, passing as soon as it answers
-http-assert --retry 30 --retry-delay 1s --assert-ok https://api.example.com/health
-
-# Bound the wait by the clock rather than by the number of attempts
-http-assert --retry 100 --retry-delay 2s --retry-max-time 1m \
-  --assert-status 200 https://api.example.com/health
-
-# Poll a local service quickly; each attempt gets 2s, the run gets 10s
-http-assert --max-time 2 --retry 50 --retry-delay 200ms --retry-max-time 10s \
-  --assert-ok http://localhost:8080/healthz
+# POST with JSON data; -d implies POST
+http-assert \
+  -H "Content-Type: application/json" \
+  -d '{"username":"test","password":"secret"}' \
+  --assert-status 201 \
+  https://api.example.com/login
 ```
 
-### Body Content Validation
+### Header Validation
 
 ```bash
-# Assert exact body content
+# Assert specific headers are present and have expected values
 http-assert \
-  --assert-body-eq "OK" \
-  https://api.example.com/ping
-
-# Assert body matches regex pattern
-http-assert \
-  --assert-body "\"users\":\s*\[\]" \
-  https://api.example.com/users
-
-# Assert empty response body
-http-assert \
-  --assert-body-empty \
-  https://api.example.com/delete-resource
+  --assert-header-eq "X-API-Version: v1" \
+  --assert-header-missing "X-Debug-Info" \
+  --assert-header "Cache-Control: max-age=\d+" \
+  https://api.example.com/data
 ```
+
+## Reference
 
 ### Environment Variables
 
@@ -550,72 +574,48 @@ Repeating `--maphost` on the command line accumulates as usual.
 - `93`: Failed to perform HTTP request, or at least one assertion failed
 - `103`: Wrong argument count, or an unknown flag
 
-## Use Cases
+### Coming from curl
 
-### CI/CD Pipeline Integration
+The flags follow `curl`'s names and semantics wherever that helps. The
+deviations are deliberate — each is a place where `curl`'s answer is wrong for
+a tool whose job is checking — and this is the complete list:
 
-```bash
-#!/bin/bash
-# Deploy and validate service
-deploy-service.sh
-
-# Wait for the service to come up, then validate the deployment. Retrying
-# replaces a fixed `sleep`: it returns as soon as the service is ready instead
-# of always waiting for the worst case, and it does not give up early when the
-# worst case is exceeded.
-http-assert \
-  --max-time 30 \
-  --retry 30 --retry-delay 1s \
-  --assert-ok \
-  --assert-header-eq "X-Service-Version: $EXPECTED_VERSION" \
-  https://api.example.com/health
-
-if [ $? -eq 0 ]; then
-  echo "Deployment validation passed"
-else
-  echo "Deployment validation failed"
-  exit 1
-fi
-```
-
-### Monitoring Script
-
-```bash
-#!/bin/bash
-# Simple monitoring script
-ENDPOINTS=(
-  "https://api.example.com/health"
-  "https://db.example.com/ping"
-  "https://cache.example.com/status"
-)
-
-for endpoint in "${ENDPOINTS[@]}"; do
-  # Two retries so a single blip does not page anyone at 3am.
-  if http-assert --silent --retry 2 --retry-delay 5s --assert-ok "$endpoint"; then
-    echo "✓ $endpoint"
-  else
-    echo "✗ $endpoint"
-  fi
-done
-```
-
-### Load Balancer Health Check
-
-```bash
-# Test all backend servers through load balancer
-BACKENDS=("backend1.internal" "backend2.internal" "backend3.internal")
-
-for backend in "${BACKENDS[@]}"; do
-  echo "Testing $backend..."
-  http-assert \
-    --maphost "api.example.com:443=$backend:8443" \
-    --assert-ok \
-    --assert-header "X-Backend-Server: $backend" \
-    https://api.example.com/health
-done
-```
+| | `curl` | `http-assert` |
+|---|---|---|
+| Redirects | not followed without `-L` | same default; `-L` additionally refuses to combine with `--assert-redirect*`, which need the 3xx it consumes |
+| `-H 'Name'` with no colon | removes the header | rejected, exit `71`; write `-H 'Name:'` to send an empty value |
+| `-d @file` | reads the file | sends the literal string `@file` |
+| `-d` repeated | values joined with `&` | rejected, exit `71` |
+| `--retry` | transport errors and a fixed set of transient statuses, exponential backoff | any failed attempt, assertion failures included, fixed delay |
+| Response decompression | opt-in via `--compressed` | always: gzip and deflate are decoded before assertions run |
+| Pointing at a backend | `--resolve host:port:addr` takes an address | `--maphost 'host:port=dst[:port]'` takes a hostname or an address |
 
 ## License
 
 `http-assert` is free software, licensed under the GNU General Public License
 v3.0 — see [LICENSE](LICENSE).
+
+## Development
+
+### Build from Repository
+
+```bash
+git clone https://github.com/korya/http-assert.git
+cd http-assert
+go build -o http-assert .
+```
+
+### Working on the Code
+
+[`just`](https://github.com/casey/just) is the task runner, and CI runs the
+same recipes:
+
+```bash
+just pre-commit   # build, tidy-check, vet, lint, gosec, unit tests, race
+just test-e2e     # end-to-end suite: builds the CLI and drives it as a subprocess
+just pre-push     # everything CI runs, including the end-to-end suite
+just test-cover   # merged unit + end-to-end coverage
+```
+
+The end-to-end tests are opt-in — `go test ./...` runs the unit tests only, and
+`-e2e` (or the recipes above) switches the full suite on.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# http-assert ![Github Actions](https://github.com/korya/http-assert/actions/workflows/build.yml/badge.svg)
+# http-assert ![Github Actions](https://github.com/korya/http-assert/actions/workflows/build.yml/badge.svg) [![Go Reference](https://pkg.go.dev/badge/github.com/korya/http-assert.svg)](https://pkg.go.dev/github.com/korya/http-assert)
 
 Make an HTTP request, assert on what comes back, exit non-zero when it's wrong.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A command-line tool for performing HTTP requests and asserting properties of the
 - **CI/CD pipelines**: Validate deployed services before proceeding with deployment
 - **Integration testing**: Test HTTP endpoints with various assertion conditions
 - **Load balancer testing**: Use host mapping to test different backend servers
-- **SSL/TLS validation**: Test secure endpoints with certificate validation options
+- **Self-signed and internal endpoints**: `--insecure` reaches hosts that cannot present a verifiable certificate
 
 ## Installation
 
@@ -20,6 +20,7 @@ No Go toolchain required. Static binaries for Linux, macOS and Windows on
 amd64 and arm64 are attached to every [release](https://github.com/korya/http-assert/releases).
 
 ```bash
+# Pick the latest tag from https://github.com/korya/http-assert/releases
 VERSION=v0.1.0
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')
@@ -94,7 +95,7 @@ A `-H` value needs a colon. A bare name exits `71` rather than being sent as a h
 | `--assert-redirect` | Assert redirect location matches regex |
 | `--assert-redirect-eq` | Assert redirect location equals exact value |
 
-The three header flags can be repeated to make several assertions of that kind. Every other assertion flag takes a single value; giving one twice exits `71` rather than silently keeping the last.
+The three header flags and `--assert-jq` can be repeated to make several assertions of that kind. Every other assertion flag takes a single value; giving one twice exits `71` rather than silently keeping the last.
 
 `--assert-ok` and `--assert-body-empty` can be negated with `=false`, which asserts the opposite rather than cancelling the flag:
 
@@ -166,10 +167,8 @@ exactly as it arrived, which is what makes `--assert-redirect` and
 `--assert-redirect-eq` possible at all -- a followed redirect has no `Location`
 header left to assert on.
 
-Callers arriving from `curl` should note that this is the opposite default.
-Combined with `--assert-ok` treating a 3xx as success, a redirecting endpoint
-passes a health check without the resource behind the redirect ever being
-fetched:
+`--assert-ok` treats a 3xx as success, so a redirecting endpoint passes a
+health check without the resource behind the redirect ever being fetched:
 
 ```console
 $ http-assert --assert-ok https://old-domain.com/health
@@ -293,10 +292,9 @@ http-assert \
   https://api.example.com/
 ```
 
-**Nothing is advertised in `Accept-Encoding` unless you ask for it.** `curl`
-sends the header on your behalf; this does not, so a server that compresses only
-on request will answer in plain. Ask with `-H` when you want to exercise content
-negotiation.
+**Nothing is advertised in `Accept-Encoding` unless you ask for it.** A server
+that compresses only on request will answer in plain; ask with
+`-H 'Accept-Encoding: gzip'` when you want to exercise content negotiation.
 
 **An encoding with no decoder here fails only the body assertions**, naming
 itself, and leaves the rest of the run intact:
@@ -323,6 +321,9 @@ way. Reading those bytes as plain text would be its own silent corruption.
 | `--verbose` | `-v` | Enable verbose logging |
 | `--silent` | `-s` | Only log errors |
 | `--log-level` | | Set log level (debug, info, warn, error) |
+
+`warn` is accepted but currently logs exactly what `error` does; nothing in the
+tool logs at the warn level.
 
 ### Other Options
 
@@ -351,8 +352,8 @@ http-assert --assert-ok https://api.example.com/health
 ### POST Request with JSON Body
 
 ```bash
-# POST with JSON data and assert specific status
-http-assert -X POST \
+# POST with JSON data; -d implies POST
+http-assert \
   -H "Content-Type: application/json" \
   -d '{"username":"test","password":"secret"}' \
   --assert-status 201 \

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ tar xzf "$ARCHIVE" http-assert
 The binary is statically linked, so it drops straight into a `scratch` or
 `distroless` image with `COPY --from`.
 
+### Shell Completion
+
+Completion scripts for bash, zsh, fish and PowerShell are built in:
+
+```bash
+http-assert completion zsh --help   # per-shell install instructions
+```
+
 ### From Source
 
 ```bash
@@ -59,6 +67,9 @@ go build -o http-assert .
 http-assert [flags] <URL>
 ```
 
+At least one `--assert-*` flag is required; a run with no assertions exits `93`
+rather than reporting a success it never checked.
+
 ### Request Options
 
 | Flag | Short | Description |
@@ -79,14 +90,16 @@ A `-H` value needs a colon. A bare name exits `71` rather than being sent as a h
 
 `-d` follows `curl`: the method becomes POST unless `-X` says otherwise, and `Content-Type: application/x-www-form-urlencoded` is set unless a `-H` provides one (`-H 'Content-Type:'` counts as providing one). Two deviations remain: `-d @file` sends the literal string `@file` rather than reading the file, and a repeated `-d` is rejected rather than joined with `&`.
 
+`--max-time` takes whole seconds; the three `--retry-*` options take durations with a unit (`1s`, `250ms`, `2m`). Requests are made over HTTP/1.1 — HTTP/2 is never attempted.
+
 ### Assertion Options
 
 | Flag | Description |
 |------|-------------|
 | `--assert-ok` | Assert the status is not an error (2xx or 3xx) |
 | `--assert-status` | Assert specific status code |
-| `--assert-header` | Assert header matches regex pattern |
-| `--assert-header-eq` | Assert header equals exact value |
+| `--assert-header` | Assert header matches regex pattern; a name alone asserts presence |
+| `--assert-header-eq` | Assert header equals exact value; a name alone asserts presence |
 | `--assert-header-missing` | Assert header is not present |
 | `--assert-body` | Assert body matches regex pattern |
 | `--assert-body-eq` | Assert body equals exact value |
@@ -321,6 +334,13 @@ way. Reading those bytes as plain text would be its own silent corruption.
 | `--verbose` | `-v` | Enable verbose logging |
 | `--silent` | `-s` | Only log errors |
 | `--log-level` | | Set log level (debug, info, warn, error) |
+
+**Everything the tool prints goes to stderr; stdout is always empty.** Use
+`2>&1` when capturing output in a file or a pipe.
+
+Each log line is prefixed with a sigil: `[.]` request sent, `[>]` redirect
+followed, `[:]` response received, `[~]` waiting to retry, and `[+]`/`[-]` for
+the verdict.
 
 `warn` is accepted but currently logs exactly what `error` does; nothing in the
 tool logs at the warn level.
@@ -594,3 +614,8 @@ for backend in "${BACKENDS[@]}"; do
     https://api.example.com/health
 done
 ```
+
+## License
+
+`http-assert` is free software, licensed under the GNU General Public License
+v3.0 — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # http-assert ![Github Actions](https://github.com/korya/http-assert/actions/workflows/build.yml/badge.svg) [![Go Reference](https://pkg.go.dev/badge/github.com/korya/http-assert.svg)](https://pkg.go.dev/github.com/korya/http-assert)
 
-`http-assert` makes an HTTP request with the flags you know from `curl` and
-checks the response against assertions declared as flags: the status code,
-headers, the body, or a `jq` expression over it. When a check fails, it exits
-non-zero and reports every failing assertion, not just the first.
+`http-assert` is `curl` with assertions: the simplest way to test a server end
+to end, or to wait for a service to come up ready.
 
 ```console
 $ http-assert --retry 30 --retry-delay 1s \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # http-assert ![Github Actions](https://github.com/korya/http-assert/actions/workflows/build.yml/badge.svg) [![Go Reference](https://pkg.go.dev/badge/github.com/korya/http-assert.svg)](https://pkg.go.dev/github.com/korya/http-assert)
 
-Make an HTTP request, assert on what comes back, exit non-zero when it's wrong.
+`http-assert` makes an HTTP request with the flags you know from `curl` and
+checks the response against assertions declared as flags: the status code,
+headers, the body, or a `jq` expression over it. When a check fails, it exits
+non-zero and reports every failing assertion, not just the first.
 
 ```console
 $ http-assert --retry 30 --retry-delay 1s \
@@ -17,9 +20,13 @@ $ http-assert --retry 30 --retry-delay 1s \
 [+] PASSED 9ms
 ```
 
-Each line is prefixed with a sigil: `[.]` request sent, `[>]` redirect
-followed, `[:]` response received, `[~]` waiting to retry, and `[+]`/`[-]` for
-the verdict. The exit code is the result.
+Every log line starts with a prefix:
+
+- `[.]` the request going out
+- `[:]` the response coming back
+- `[>]` a redirect being followed
+- `[~]` a wait before the next attempt
+- `[+]` / `[-]` the verdict
 
 ## Why
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The stock answers each see half the picture:
   a bare exit code, nothing retries while the service comes up, and the
   healthcheck image now needs `curl` *and* `jq` in it.
 
-`http-assert` is the missing middle: one static binary. It makes the request,
+`http-assert` closes that gap with one static binary. It makes the request,
 checks status, headers and body in one pass, and retries until the service is
 ready. When a check fails, it reports every failing assertion with what it
 actually saw:
@@ -56,6 +56,8 @@ Built for the places where the exit code is the whole point:
 
 - **Deploy gates**: replace `sleep 10; curl -f` with a poll that passes the
   moment the service is ready and fails with evidence when it never is
+- **End-to-end tests**: send the real request with `-X`, `-H` and `-d`, and
+  assert on everything that comes back
 - **Container healthchecks**: statically linked, drops into a `scratch` or
   `distroless` image with `COPY --from`
 - **Monitoring probes**: reports that name every failed check and stay

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ The stock answers each see half the picture:
   a bare exit code, nothing retries while the service comes up, and the
   healthcheck image now needs `curl` *and* `jq` in it.
 
-`http-assert` is the missing middle: one static binary that makes the request,
-checks status, headers and body in a single pass, retries until the service is
-ready, and — when the check fails — reports every failing assertion with what
-it actually saw:
+`http-assert` is the missing middle: one static binary. It makes the request,
+checks status, headers and body in one pass, and retries until the service is
+ready. When a check fails, it reports every failing assertion with what it
+actually saw:
 
 ```console
 $ http-assert --assert-status 200 --assert-jq '.status == "healthy"' https://api.example.com/health
@@ -49,18 +49,18 @@ Error: Cannot perform request: 2 assertions failed:
 
 Built for the places where the exit code is the whole point:
 
-- **Deploy gates** — replace `sleep 10; curl -f` with a poll that passes the
+- **Deploy gates**: replace `sleep 10; curl -f` with a poll that passes the
   moment the service is ready and fails with evidence when it never is
-- **Container healthchecks** — statically linked, drops into a `scratch` or
+- **Container healthchecks**: statically linked, drops into a `scratch` or
   `distroless` image with `COPY --from`
-- **Monitoring probes** — aggregated failure reports that read well in a CI
-  log, no ANSI codes
-- **Backend verification** — `--maphost` aims the same request at a specific
+- **Monitoring probes**: reports that name every failed check and stay
+  readable in a plain CI log
+- **Backend verification**: `--maphost` aims the same request at a specific
   backend behind a load balancer
 
 The flags follow `curl` where that helps; where a checking tool needs a
-different answer, the deviation is deliberate and documented — see
-[Coming from curl](#coming-from-curl).
+different answer, the deviation is deliberate, and
+[Coming from curl](#coming-from-curl) lists every one.
 
 ## Contents
 
@@ -140,11 +140,11 @@ rather than reporting a success it never checked.
 | `--retry-delay` | | Delay between attempts (default: 1s) |
 | `--retry-max-time` | | Stop retrying after this long (default: no limit) |
 
-A `-H` value needs a colon. A bare name exits `71` rather than being sent as a header with an empty value, which is what `curl` reads as "remove this header" — so the two would have meant opposite things. Write `-H 'X-Foo:'` when an empty value is what you want.
+A `-H` value needs a colon. A bare name exits `71` rather than being sent as a header with an empty value, which is what `curl` reads as "remove this header", so the two would have meant opposite things. Write `-H 'X-Foo:'` when an empty value is what you want.
 
 `-d` follows `curl`: the method becomes POST unless `-X` says otherwise, and `Content-Type: application/x-www-form-urlencoded` is set unless a `-H` provides one (`-H 'Content-Type:'` counts as providing one). Two deviations remain: `-d @file` sends the literal string `@file` rather than reading the file, and a repeated `-d` is rejected rather than joined with `&`.
 
-`--max-time` takes whole seconds; the three `--retry-*` options take durations with a unit (`1s`, `250ms`, `2m`). Requests are made over HTTP/1.1 — HTTP/2 is never attempted.
+`--max-time` takes whole seconds; the three `--retry-*` options take durations with a unit (`1s`, `250ms`, `2m`). Requests use HTTP/1.1; HTTP/2 is never attempted.
 
 ### Assertion Options
 
@@ -174,7 +174,7 @@ http-assert --assert-ok=false https://api.example.com/forbidden
 http-assert --assert-body-empty=false https://api.example.com/report
 ```
 
-The three body assertions run against the decoded payload, never the bytes on the wire — see [Compression](#compression).
+The three body assertions run against the decoded payload, never the bytes on the wire; see [Compression](#compression).
 
 ### JSON Assertions
 
@@ -541,7 +541,7 @@ http-assert --assert-ok https://api.example.com
 
 #### Proxies
 
-`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are honoured for the request itself. There is no flag for them, and no way to disable the behaviour from the command line — if one of these is set in your environment for unrelated reasons, requests go through it.
+`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are honoured for the request itself. There is no flag for them, and no way to disable the behaviour from the command line: if one of these is set in your environment for unrelated reasons, requests go through it.
 
 **A value that does not parse is rejected** rather than ignored, so a typo cannot silently change behaviour:
 
@@ -577,8 +577,8 @@ Repeating `--maphost` on the command line accumulates as usual.
 ### Coming from curl
 
 The flags follow `curl`'s names and semantics wherever that helps. The
-deviations are deliberate — each is a place where `curl`'s answer is wrong for
-a tool whose job is checking — and this is the complete list:
+deviations are deliberate, each one a place where `curl`'s answer is wrong for
+a tool whose job is checking. This is the complete list:
 
 | | `curl` | `http-assert` |
 |---|---|---|
@@ -593,7 +593,7 @@ a tool whose job is checking — and this is the complete list:
 ## License
 
 `http-assert` is free software, licensed under the GNU General Public License
-v3.0 — see [LICENSE](LICENSE).
+v3.0; see [LICENSE](LICENSE).
 
 ## Development
 
@@ -617,5 +617,5 @@ just pre-push     # everything CI runs, including the end-to-end suite
 just test-cover   # merged unit + end-to-end coverage
 ```
 
-The end-to-end tests are opt-in — `go test ./...` runs the unit tests only, and
+The end-to-end tests are opt-in: `go test ./...` runs the unit tests only, and
 `-e2e` (or the recipes above) switches the full suite on.

--- a/main.go
+++ b/main.go
@@ -6,9 +6,9 @@
 // declared as flags, and the request is made once and checked against all of
 // them.
 //
-// The three header assertions can be repeated to assert several things at
-// once. Every other assertion flag takes a single value and is rejected if
-// given twice, rather than quietly keeping the last one.
+// The three header assertions and --assert-jq can be repeated to assert
+// several things at once. Every other assertion flag takes a single value and
+// is rejected if given twice, rather than quietly keeping the last one.
 //
 // The two boolean assertions negate with =false, which selects the opposite
 // assertion rather than cancelling the flag.
@@ -129,9 +129,10 @@ func main() {
 Assertions are declared as flags. The request is made once and checked
 against all of them, and every failure is reported, not just the first.
 
-Repeat --assert-header, --assert-header-eq or --assert-header-missing to make
-several assertions of that kind. Every other assertion flag takes a single
-value and is rejected if given twice, rather than quietly keeping the last.
+Repeat --assert-header, --assert-header-eq, --assert-header-missing or
+--assert-jq to make several assertions of that kind. Every other assertion flag
+takes a single value and is rejected if given twice, rather than quietly
+keeping the last.
 
 The two boolean assertions can be negated with =false, which selects the
 opposite assertion rather than cancelling the flag: --assert-ok=false asserts
@@ -167,9 +168,8 @@ Redirects:
   not followed. That is what --assert-redirect and --assert-redirect-eq
   assert against.
 
-  This is the opposite of curl's default, and --assert-ok counts a 3xx as
-  success, so a redirecting endpoint passes a health check without the
-  resource behind it ever being fetched.
+  --assert-ok counts a 3xx as success, so a redirecting endpoint passes a
+  health check without the resource behind it ever being fetched.
 
   -L follows the chain, and every assertion then applies to the response at
   the end of it. --max-redirs bounds the chain and needs -L to mean anything.


### PR DESCRIPTION
## Problem

The README talked past its readers: the product first appeared around line 100, six claims in it were false, and the basic contract was written down nowhere.

The file had grown by accretion. The opening was badges, a feature list and 37 lines of install scripting. The old Examples section predated the per-feature documentation and had become two-thirds duplicate of it — one subsection still teaching the regex-over-JSON idiom the JSON section above it forbids. A would-be contributor found `go build` and nothing else. And a reader could not learn from the README that at least one assertion is required, that all output goes to stderr, or what `[.]` `[:]` `[+]` mean in the output they were shown six times.

The false claims are the part that made this three commits rather than one. Each was checked against the running binary or against `curl` itself, and two were only discovered by that checking:

| Claim | Reality |
|---|---|
| "Every other assertion flag takes a single value" (three surfaces) | `--assert-jq` repeats — stale since #43 |
| Not following redirects "is the opposite of curl's default" (two surfaces) | curl does not follow without `-L` either; verified against curl 8, the defaults are the same |
| "curl sends the Accept-Encoding header on your behalf" | curl sends `Accept`, `Host`, `User-Agent` and nothing else without `--compressed`; verified against a live echo |
| "SSL/TLS validation … certificate validation options" | the only option is `-k`, which disables verification |
| `--log-level` lists `warn` as a working level | `warn` logs exactly what `error` does; nothing logs at warn |

## Solution

Four commits, ordered so each stands alone: correct, then complete, then restructure, then an editing pass that strips the em dashes and generated-prose tics from the new copy.

**`docs:` Correct the claims the docs do not honour** — the five above plus two staleness fixes (`VERSION=v0.1.0` frozen in the install snippet, `-X POST` beside a `-d` that already implies it). The single-value and redirect sentences are fixed in the README, the package comment *and* `--help`, which had all drifted together.

**`docs(readme):` Document the contract the tool already keeps** — eight facts that were implemented and pinned by tests but absent: an assertion is required (exit 93 without one); everything prints to stderr; the sigil legend; the bare-name presence shorthand for `--assert-header`/`--assert-header-eq`; HTTP/1.1 only; `--max-time` in seconds vs `--retry-*` durations; the built-in `completion` subcommand; and a License section — the project is GPL-3.0, previously discoverable only by opening LICENSE.

**`docs(readme):` Restructure for readers before contributors** — the audience order: a real run first (fail → retry → pass, legend beside it), then Why, then usage, recipes, reference, development.

The Why section is the selling half, and it is deliberately show-don't-tell: the failure report is the pitch. Its comparison bullets were validated empirically before being written, which killed one of them — the draft claimed `curl | jq -e` silently passes when curl fails absent `pipefail`; tested, it does not (`jq -e` exits 4 on empty input). The verified replacement is stronger: **`curl -f` passes a 200 whose body says degraded, and `curl -s | jq -e` passes a 503 whose body says ok** — each tool blind to the half the other checks.

The rest of the restructure: Examples ∪ Use Cases → one Recipes section (five duplicate subsections deleted); a Coming-from-curl table collecting the deviations previously scattered one per section; a Development section with the `just` recipes and the e2e opt-in; the Go Reference badge dropped, since it documents a `package main` nothing can import.

No test parses the README (verified — both grep hits are comments), and the `main.go` edits are string literals only; `just pre-push` is green after each commit.

## Other Changes

The error message for a repeated single-value assertion still names only the three header flags as repeatable, omitting `--assert-jq`. It is behaviour rather than documentation (tests pin adjacent text), so it is left for a follow-up rather than smuggled into a docs PR.

There are no screenshots because there is no rendered UI; this tool's user-visible surface is terminal output, quoted throughout the new README.

Related:
- https://github.com/korya/http-assert/issues/34 — the stderr-only behaviour is now documented; that issue remains the place to change it
- https://github.com/korya/http-assert/issues/36 — the completion subcommand is now documented; the URL-shadowing half remains open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EMMhgmTkbzAsmeNy97PrP

