### PR TITLE
Reduce exit codes to invocation, transport and assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ actually saw:
 ```console
 $ http-assert --assert-status 200 --assert-jq '.status == "healthy"' https://api.example.com/health
 
-Error: Cannot perform request: 2 assertions failed:
+Error: 2 assertions failed:
 - status: expected 200, got 503 ("503 Service Unavailable")
 - jq[.status == "healthy"]: expected true, got "degraded"
 ```
@@ -128,7 +128,7 @@ go install github.com/korya/http-assert@latest
 http-assert [flags] <URL>
 ```
 
-At least one `--assert-*` flag is required; a run with no assertions exits `93`
+At least one `--assert-*` flag is required; a run with no assertions exits `71`
 rather than reporting a success it never checked.
 
 ### Request Options
@@ -266,7 +266,7 @@ $ http-assert -L --assert-status 200 https://old-domain.com/health
 ```
 
 `--max-redirs` bounds the chain and defaults to 10. `--max-redirs 0` refuses
-every redirect, as in `curl`. Exceeding the bound exits `93` and says so
+every redirect, as in `curl`. Exceeding the bound exits `92` and says so
 explicitly, rather than reporting a network failure that did not happen. The
 option needs `-L` to mean anything, so passing it alone exits `71` rather than
 being quietly ignored.
@@ -318,7 +318,7 @@ at the defaults, over ten minutes. `--retry-max-time` bounds the run instead:
 ```console
 $ http-assert --retry 100 --retry-delay 5s --retry-max-time 30s --assert-ok https://api.example.com/health
 ...
-Error: Cannot perform request: gave up after 6 attempts (--retry-max-time is 30s):
+Error: gave up after 6 attempts (--retry-max-time is 30s):
 ```
 
 The budget is checked before each retry rather than enforced mid-request, as in
@@ -575,11 +575,19 @@ Repeating `--maphost` on the command line accumulates as usual.
 
 ### Exit Codes
 
+The code answers whose fault the failure is — the invocation, the transport,
+or the response:
+
 - `0`: All assertions passed, or `--version`/`--help` was requested
-- `71`: A flag or environment value was rejected
-- `91`: The request could not be constructed from the method and URL
-- `93`: Failed to perform HTTP request, or at least one assertion failed
-- `103`: Wrong argument count, or an unknown flag
+- `71`: The invocation was rejected — a bad flag, value, combination or
+  argument count — and no request was attempted
+- `92`: The request produced no usable response (unreachable host, TLS
+  failure, timeout, redirect bound exceeded)
+- `93`: A response arrived, and at least one assertion failed
+
+Before v0.2 there were five codes: `91` (unbuildable request) and `103`
+(argument/flag syntax) are now `71`, and transport failures moved from `93`
+to `92`, so `93` now always means "the service answered wrongly".
 
 ### Coming from curl
 

--- a/e2e_assert_test.go
+++ b/e2e_assert_test.go
@@ -34,7 +34,7 @@ func TestE2EAssertions(t *testing.T) {
 
 			t.Run("does not hold", func(t *testing.T) {
 				r := run(t, nil, append(append([]string{}, tc.Args...), tc.Fail)...)
-				assertExit(t, r, exitRequestFail)
+				assertExit(t, r, exitAssertFail)
 				assertContains(t, r, tc.Diag)
 			})
 		})
@@ -51,7 +51,7 @@ func TestE2EAssertionAggregation(t *testing.T) {
 		"--assert-body-eq", "not-boom",
 		url("/500"))
 
-	assertExit(t, r, exitRequestFail)
+	assertExit(t, r, exitAssertFail)
 	assertContains(t, r, "4 assertions failed:")
 	for _, want := range []string{"ok: expected OK", "status: expected 200", "header[X-Absent]", "body: expected"} {
 		assertContains(t, r, want)
@@ -69,18 +69,25 @@ func TestE2EExitCodes(t *testing.T) {
 		Diag string
 	}{
 		{Name: "success", Args: []string{"--assert-ok", url("/ok")}, Want: exitOK},
-		{Name: "assertion failed", Args: []string{"--assert-ok", url("/500")}, Want: exitRequestFail, Diag: "assertions failed"},
-		{Name: "connection refused", Args: []string{"--assert-ok", "http://127.0.0.1:9/"}, Want: exitRequestFail, Diag: "failed to send request"},
-		{Name: "dns failure", Args: []string{"--assert-ok", "http://nonexistent.invalid/"}, Want: exitRequestFail, Diag: "failed to send request"},
-		{Name: "unsupported scheme", Args: []string{"--assert-ok", "ftp://example.com/x"}, Want: exitRequestFail, Diag: "unsupported protocol scheme"},
-		{Name: "tls verification", Args: []string{"--assert-ok", tlsSrv.URL}, Want: exitRequestFail, Diag: "certificate"},
-		{Name: "invalid log level", Args: []string{"--log-level", "trace", "--assert-ok", url("/ok")}, Want: exitBadFlagVal, Diag: "Invalid value for --log-level"},
-		{Name: "invalid maphost", Args: []string{"--maphost", "garbage", "--assert-ok", url("/ok")}, Want: exitBadFlagVal, Diag: "Invalid value for --maphost"},
-		{Name: "invalid method", Args: []string{"-X", "BAD METHOD", "--assert-ok", url("/ok")}, Want: exitBadRequest, Diag: "Cannot create request"},
-		{Name: "malformed url", Args: []string{"--assert-ok", "ht!tp://[bad"}, Want: exitBadRequest, Diag: "Cannot create request"},
-		{Name: "no url", Args: []string{"--assert-ok"}, Want: exitUsage, Diag: "accepts 1 arg(s)"},
-		{Name: "too many urls", Args: []string{"--assert-ok", url("/ok"), url("/created")}, Want: exitUsage, Diag: "accepts 1 arg(s)"},
-		{Name: "unknown flag", Args: []string{"--nope", url("/ok")}, Want: exitUsage, Diag: "unknown flag"},
+		{Name: "assertion failed", Args: []string{"--assert-ok", url("/500")}, Want: exitAssertFail, Diag: "assertions failed"},
+		{Name: "connection refused", Args: []string{"--assert-ok", "http://127.0.0.1:9/"}, Want: exitTransportFail, Diag: "failed to send request"},
+		{Name: "dns failure", Args: []string{"--assert-ok", "http://nonexistent.invalid/"}, Want: exitTransportFail, Diag: "failed to send request"},
+		{Name: "unsupported scheme", Args: []string{"--assert-ok", "ftp://example.com/x"}, Want: exitTransportFail, Diag: "unsupported protocol scheme"},
+		{Name: "tls verification", Args: []string{"--assert-ok", tlsSrv.URL}, Want: exitTransportFail, Diag: "certificate"},
+		{Name: "invalid log level", Args: []string{"--log-level", "trace", "--assert-ok", url("/ok")}, Want: exitBadInvocation, Diag: "Invalid value for --log-level"},
+		{Name: "invalid maphost", Args: []string{"--maphost", "garbage", "--assert-ok", url("/ok")}, Want: exitBadInvocation, Diag: "Invalid value for --maphost"},
+		{Name: "invalid method", Args: []string{"-X", "BAD METHOD", "--assert-ok", url("/ok")}, Want: exitBadInvocation, Diag: "Cannot create request"},
+		{Name: "malformed url", Args: []string{"--assert-ok", "ht!tp://[bad"}, Want: exitBadInvocation, Diag: "Cannot create request"},
+		{Name: "no url", Args: []string{"--assert-ok"}, Want: exitBadInvocation, Diag: "accepts 1 arg(s)"},
+		{Name: "too many urls", Args: []string{"--assert-ok", url("/ok"), url("/created")}, Want: exitBadInvocation, Diag: "accepts 1 arg(s)"},
+		{Name: "unknown flag", Args: []string{"--nope", url("/ok")}, Want: exitBadInvocation, Diag: "unknown flag"},
+		// Flipped by #25: detected before any request, so it is an invocation
+		// error, not the transport failure it used to report.
+		{Name: "no assertions", Args: []string{url("/ok")}, Want: exitBadInvocation, Diag: "No assertions specified"},
+		// The same typo through either channel exits the same way; these two
+		// used to differ (103 with a usage dump vs 71 with one line).
+		{Name: "value typo on the command line", Args: []string{"-m", "abc", "--assert-ok", url("/ok")}, Want: exitBadInvocation, Diag: "invalid argument"},
+		{Name: "value typo in the environment", Env: map[string]string{"HTTP_ASSERT_MAX_TIME": "abc"}, Args: []string{"--assert-ok", url("/ok")}, Want: exitBadInvocation, Diag: "Invalid value for HTTP_ASSERT_MAX_TIME"},
 	}
 
 	for _, tc := range cases {
@@ -233,8 +240,10 @@ func TestE2EHostMapping(t *testing.T) {
 	})
 
 	t.Run("unmapped hosts are untouched", func(t *testing.T) {
+		// The unmapped .invalid host fails DNS, so this is a transport
+		// failure: proof the mapping was not applied.
 		r := run(t, nil, "--maphost", "other.invalid:80="+hostPort(), "--assert-ok", target)
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitTransportFail)
 	})
 
 	t.Run("mapping is logged at debug level", func(t *testing.T) {
@@ -292,7 +301,7 @@ func TestE2EHeaderPresenceAssertions(t *testing.T) {
 
 			t.Run("absent", func(t *testing.T) {
 				r := run(t, nil, flag, "X-Api-Version", url("/created"))
-				assertExit(t, r, exitRequestFail)
+				assertExit(t, r, exitAssertFail)
 				assertContains(t, r, "expected to be present")
 			})
 		})
@@ -303,7 +312,7 @@ func TestE2EHeaderPresenceAssertions(t *testing.T) {
 // over 256 bytes are truncated and the hidden byte count is reported.
 func TestE2ELargePayloadCropped(t *testing.T) {
 	r := run(t, nil, "--assert-body-eq", "never-matches", url("/big"))
-	assertExit(t, r, exitRequestFail)
+	assertExit(t, r, exitAssertFail)
 	assertContains(t, r, "Payload is cropped")
 	assertContains(t, r, "4744 bytes are hidden")
 }
@@ -325,14 +334,14 @@ func TestE2EAssertEmptyBody(t *testing.T) {
 	// The inverse still fails, so the fix did not simply stop checking.
 	t.Run("--assert-body-eq '' fails against a body", func(t *testing.T) {
 		r := run(t, nil, "--assert-body-eq", "", url("/ok"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, `body: expected "", got`)
 	})
 
 	// And the wording that the old guard existed to produce is still there.
 	t.Run("an empty body still reports as missing", func(t *testing.T) {
 		r := run(t, nil, "--assert-body-eq", "value", url("/empty"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, `body: expected "value", missing`)
 	})
 }
@@ -349,15 +358,15 @@ func TestE2EAssertBooleanNegation(t *testing.T) {
 	}{
 		// --assert-ok, both directions, both outcomes.
 		{"--assert-ok on a 200", []string{"--assert-ok", url("/ok")}, exitOK},
-		{"--assert-ok on a 500", []string{"--assert-ok", url("/500")}, exitRequestFail},
+		{"--assert-ok on a 500", []string{"--assert-ok", url("/500")}, exitAssertFail},
 		{"--assert-ok=false on a 500", []string{"--assert-ok=false", url("/500")}, exitOK},
-		{"--assert-ok=false on a 200", []string{"--assert-ok=false", url("/ok")}, exitRequestFail},
+		{"--assert-ok=false on a 200", []string{"--assert-ok=false", url("/ok")}, exitAssertFail},
 
 		// --assert-body-empty, the same four.
 		{"--assert-body-empty on a 204", []string{"--assert-body-empty", url("/empty")}, exitOK},
-		{"--assert-body-empty on a body", []string{"--assert-body-empty", url("/ok")}, exitRequestFail},
+		{"--assert-body-empty on a body", []string{"--assert-body-empty", url("/ok")}, exitAssertFail},
 		{"--assert-body-empty=false on a body", []string{"--assert-body-empty=false", url("/ok")}, exitOK},
-		{"--assert-body-empty=false on a 204", []string{"--assert-body-empty=false", url("/empty")}, exitRequestFail},
+		{"--assert-body-empty=false on a 204", []string{"--assert-body-empty=false", url("/empty")}, exitAssertFail},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			assertExit(t, run(t, nil, tc.Args...), tc.Want)
@@ -377,7 +386,7 @@ func TestE2EAssertBooleanNegation(t *testing.T) {
 	// exactly as repeating the positive form is.
 	t.Run("a repeated negation is still refused", func(t *testing.T) {
 		r := run(t, nil, "--assert-ok", "--assert-ok=false", url("/ok"))
-		assertExit(t, r, exitBadFlagVal)
+		assertExit(t, r, exitBadInvocation)
 		assertContains(t, r, "was given 2 times")
 	})
 }
@@ -415,7 +424,7 @@ func TestE2EHeaderRequiresASeparator(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			r := run(t, nil, "-H", tc.Arg, "--assert-ok", url("/ok"))
-			assertExit(t, r, exitBadFlagVal)
+			assertExit(t, r, exitBadInvocation)
 			assertContains(t, r, tc.Diag)
 		})
 	}
@@ -428,7 +437,7 @@ func TestE2EHeaderRequiresASeparator(t *testing.T) {
 	// the validation itself is not what lets the single case through.
 	t.Run("an empty value alongside another", func(t *testing.T) {
 		r := run(t, nil, "-H", "X-Ok: 1", "-H", "", "--assert-ok", url("/ok"))
-		assertExit(t, r, exitBadFlagVal)
+		assertExit(t, r, exitBadInvocation)
 		assertContains(t, r, "has no ':' separator")
 	})
 
@@ -482,7 +491,7 @@ func TestE2EBadPatternIsRejected(t *testing.T) {
 		t.Run(tc.Flag, func(t *testing.T) {
 			r := run(t, nil, tc.Flag, tc.Arg, url("/ok"))
 
-			assertExit(t, r, exitBadFlagVal)
+			assertExit(t, r, exitBadInvocation)
 			// The flag at fault is named, and the parser's reason survives.
 			assertContains(t, r, "Invalid value for "+tc.Flag+" flag")
 			assertContains(t, r, "error parsing regexp")

--- a/e2e_compression_test.go
+++ b/e2e_compression_test.go
@@ -84,7 +84,7 @@ func TestE2ECompressionNoFalsePass(t *testing.T) {
 	// now fail, because the compressed form is not what gets asserted on.
 	bad := run(t, nil, "-H", "Accept-Encoding: gzip",
 		"--assert-body", `\x1f\x8b`, url("/gzip"))
-	assertExit(t, bad, exitRequestFail)
+	assertExit(t, bad, exitAssertFail)
 }
 
 // TestE2ECompressionHeadersSurvive pins the half of the fix that is not about
@@ -106,7 +106,7 @@ func TestE2ECompressionHeadersSurvive(t *testing.T) {
 	t.Run("nothing is advertised unless asked", func(t *testing.T) {
 		r := run(t, nil, "--assert-body", `"headers"`,
 			"--assert-body-eq", "never-matches", url("/echo"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertNotContains(t, r, "Accept-Encoding")
 	})
 }
@@ -128,7 +128,7 @@ func TestE2ECompressionUndecodable(t *testing.T) {
 
 	t.Run("a body check refuses, and names the encoding", func(t *testing.T) {
 		r := run(t, nil, "--assert-body", `"status":"success"`, url("/brotli"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "body: response is br-encoded and was not decoded")
 		assertContains(t, r, "no decoder for \"br\"")
 		// The old failure was a bare hex dump with nothing explaining it.
@@ -139,7 +139,7 @@ func TestE2ECompressionUndecodable(t *testing.T) {
 	// bytes as plain would be its own silent corruption.
 	t.Run("a body that does not match its stated encoding", func(t *testing.T) {
 		r := run(t, nil, "--assert-body-eq", `{"status":"success"}`, url("/gzip-corrupt"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "body: response is gzip-encoded and was not decoded")
 	})
 }
@@ -150,7 +150,7 @@ func TestE2ECompressionUndecodable(t *testing.T) {
 func TestE2ECompressionFailureDumpExplainsItself(t *testing.T) {
 	r := run(t, nil, "-H", "Accept-Encoding: gzip",
 		"--assert-body-eq", "never-matches", url("/gzip"))
-	assertExit(t, r, exitRequestFail)
+	assertExit(t, r, exitAssertFail)
 
 	assertContains(t, r, "Content-Encoding: gzip")
 	assertContains(t, r, "<< Payload decoded from gzip >>")

--- a/e2e_config_test.go
+++ b/e2e_config_test.go
@@ -40,7 +40,7 @@ type configCase struct {
 
 // noAssertions is the error the CLI emits when no --assert-* flag was parsed.
 // For every assertion option, "did it apply?" reduces to "is this absent?".
-const noAssertions = "no assertions defined"
+const noAssertions = "No assertions specified"
 
 func assertionApplied(r result) bool { return !strings.Contains(r.Output(), noAssertions) }
 
@@ -246,7 +246,7 @@ func TestE2EConfigPrecedence(t *testing.T) {
 		if !timedOut(r) {
 			t.Fatalf("env won over the command line; the request completed\n%s", r.Output())
 		}
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitTransportFail)
 	})
 
 	t.Run("environment beats the built-in default", func(t *testing.T) {
@@ -282,7 +282,7 @@ func TestE2EConfigEnvSliceSeparator(t *testing.T) {
 			"--assert-ok", target)
 		// The whole string is taken as one mapping, whose destination port is
 		// then unparseable.
-		assertExit(t, r, exitBadFlagVal)
+		assertExit(t, r, exitBadInvocation)
 		assertContains(t, r, "Invalid value for --maphost flag")
 	})
 
@@ -374,7 +374,7 @@ func TestE2EConfigEnvInvalidValues(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			r := run(t, tc.Env, append(tc.Args, "--assert-ok", url("/ok"))...)
-			assertExit(t, r, exitBadFlagVal)
+			assertExit(t, r, exitBadInvocation)
 			assertContains(t, r, tc.Diag)
 			// The reason is passed through rather than swallowed.
 			assertContains(t, r, "invalid syntax")
@@ -385,13 +385,13 @@ func TestE2EConfigEnvInvalidValues(t *testing.T) {
 	// them and their own parsers reject them. Same exit code, different message.
 	t.Run("log-level is validated by the level parser", func(t *testing.T) {
 		r := run(t, map[string]string{"HTTP_ASSERT_LOG_LEVEL": "trace"}, "--assert-ok", url("/ok"))
-		assertExit(t, r, exitBadFlagVal)
+		assertExit(t, r, exitBadInvocation)
 		assertContains(t, r, `Invalid value for --log-level flag: "trace"`)
 	})
 
 	t.Run("maphost is validated by the mapping parser", func(t *testing.T) {
 		r := run(t, map[string]string{"HTTP_ASSERT_MAPHOST": "garbage"}, "--assert-ok", url("/ok"))
-		assertExit(t, r, exitBadFlagVal)
+		assertExit(t, r, exitBadInvocation)
 		assertContains(t, r, "Invalid value for --maphost flag")
 	})
 }
@@ -429,7 +429,7 @@ func TestE2EConfigEnvBooleanForms(t *testing.T) {
 		for _, v := range []string{"yes", "on", "no", "off", "y", "n"} {
 			t.Run(v, func(t *testing.T) {
 				r := run(t, map[string]string{"HTTP_ASSERT_VERBOSE": v}, base...)
-				assertExit(t, r, exitBadFlagVal)
+				assertExit(t, r, exitBadInvocation)
 				assertContains(t, r, "Invalid value for HTTP_ASSERT_VERBOSE")
 			})
 		}

--- a/e2e_dump_test.go
+++ b/e2e_dump_test.go
@@ -20,7 +20,7 @@ func TestE2EFailureDump(t *testing.T) {
 	// placeholder down to "  <<".
 	t.Run("omitted placeholder is not cut to the body length", func(t *testing.T) {
 		r := run(t, nil, "-s", "--assert-ok", url("/500"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "  << Payload is omitted >>")
 	})
 
@@ -28,7 +28,7 @@ func TestE2EFailureDump(t *testing.T) {
 	// else, from a dumper whose entire purpose is showing the bytes.
 	t.Run("binary body keeps its hex dump and ascii gutter", func(t *testing.T) {
 		r := run(t, nil, "--assert-body-eq", "never-matches", url("/binary"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "00000000")
 		assertContains(t, r, "00 01 02 03 ff fe 07 08")
 		assertContains(t, r, "|")
@@ -39,7 +39,7 @@ func TestE2EFailureDump(t *testing.T) {
 	// zero terminator, plus a Transfer-Encoding header it invented.
 	t.Run("chunked response is dumped without transfer framing", func(t *testing.T) {
 		r := run(t, nil, "-v", "--assert-body-eq", "never-matches", url("/chunked"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "first chunk second chunk")
 		assertNotContains(t, r, "Transfer-Encoding")
 
@@ -58,7 +58,7 @@ func TestE2EFailureDump(t *testing.T) {
 	// -- pretty-printed JSON, HTML, a log excerpt -- was shown as a hex dump.
 	t.Run("multi-line text body is shown as text", func(t *testing.T) {
 		r := run(t, nil, "--assert-body-eq", "never-matches", url("/multiline"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "\"status\": \"success\"")
 		assertNotContains(t, r, "00000000")
 	})
@@ -67,7 +67,7 @@ func TestE2EFailureDump(t *testing.T) {
 	// survive the change.
 	t.Run("large body is still cropped and says so", func(t *testing.T) {
 		r := run(t, nil, "--assert-body-eq", "never-matches", url("/big"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "Payload is cropped")
 		assertContains(t, r, "bytes are hidden")
 	})
@@ -76,7 +76,7 @@ func TestE2EFailureDump(t *testing.T) {
 	// some CI log viewers.
 	t.Run("dump uses newlines rather than wire line endings", func(t *testing.T) {
 		r := run(t, nil, "-s", "--assert-ok", url("/500"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 
 		// The request half is still serialized by http.Request.Write and keeps
 		// its CRLFs; #19 replaces it. Only the response half is checked here.

--- a/e2e_harness_test.go
+++ b/e2e_harness_test.go
@@ -157,13 +157,13 @@ func isProxyVar(name string) bool {
 }
 
 // Exit codes the CLI is contracted to return. Nothing in the repo documented
-// these before this suite existed; see #24.
+// these before this suite existed (see #24); the categories shrank to three
+// when the invocation/transport/assertion model landed.
 const (
-	exitOK          = 0   // every assertion passed
-	exitBadFlagVal  = 71  // a flag value failed to parse (--log-level, --maphost)
-	exitBadRequest  = 91  // the request could not be constructed (-X, URL)
-	exitRequestFail = 93  // transport failure, or at least one assertion failed
-	exitUsage       = 103 // wrong argument count, unknown flag
+	exitOK            = 0  // every assertion passed
+	exitBadInvocation = 71 // the invocation was rejected; no request attempted
+	exitTransportFail = 92 // the request produced no usable response
+	exitAssertFail    = 93 // a response arrived and at least one assertion failed
 )
 
 // assertExit fails the test with full context when the exit code is unexpected.

--- a/e2e_help_test.go
+++ b/e2e_help_test.go
@@ -21,18 +21,21 @@ func TestE2EHelpDocumentsTheContract(t *testing.T) {
 	assertExit(t, r, exitOK)
 
 	t.Run("every exit code the CLI can return is listed", func(t *testing.T) {
-		for _, code := range []int{exitOK, exitBadFlagVal, exitBadRequest, exitRequestFail, exitUsage} {
+		for _, code := range []int{exitOK, exitBadInvocation, exitTransportFail, exitAssertFail} {
 			if !strings.Contains(r.Output(), fmt.Sprintf("\n  %d ", code)) {
 				t.Errorf("--help does not document exit code %d", code)
 			}
 		}
 	})
 
-	// Exit 2 was the Go panic path. #61 removed it and TestE2ENoFlagPanics
-	// keeps it removed, so it is deliberately absent rather than overlooked.
-	t.Run("the panic exit code is not advertised", func(t *testing.T) {
-		if strings.Contains(r.Output(), "\n  2 ") {
-			t.Error("--help documents exit code 2, which the CLI can no longer return")
+	// Exit 2 was the Go panic path (#61); 91 and 103 merged into the
+	// invocation code when the categories shrank to three. All are
+	// deliberately absent rather than overlooked.
+	t.Run("retired exit codes are not advertised", func(t *testing.T) {
+		for _, code := range []int{2, 91, 103} {
+			if strings.Contains(r.Output(), fmt.Sprintf("\n  %d ", code)) {
+				t.Errorf("--help documents exit code %d, which the CLI can no longer return", code)
+			}
 		}
 	})
 

--- a/e2e_jq_test.go
+++ b/e2e_jq_test.go
@@ -14,7 +14,7 @@ func TestE2EAssertJQ(t *testing.T) {
 
 	t.Run("a query that does not", func(t *testing.T) {
 		r := run(t, nil, "--assert-jq", `.status == "nope"`, url("/json"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		// The failure names the query, because a run can carry several.
 		assertContains(t, r, `jq[.status == "nope"]: expected true, got false`)
 	})
@@ -56,7 +56,7 @@ func TestE2EAssertJQAccumulates(t *testing.T) {
 			"--assert-jq", `.status == "success"`,
 			"--assert-jq", `.count == 99`,
 			url("/json"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, `jq[.count == 99]`)
 	})
 
@@ -65,7 +65,7 @@ func TestE2EAssertJQAccumulates(t *testing.T) {
 			"--assert-jq", `.count == 99`,
 			"--assert-jq", `.status == "success"`,
 			url("/json"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, `jq[.count == 99]`)
 	})
 
@@ -76,7 +76,7 @@ func TestE2EAssertJQAccumulates(t *testing.T) {
 			"--assert-jq", `.count == 98`,
 			"--assert-jq", `.count == 99`,
 			url("/json"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "2 assertions failed:")
 		assertContains(t, r, `jq[.count == 98]`)
 		assertContains(t, r, `jq[.count == 99]`)
@@ -105,7 +105,7 @@ func TestE2EAssertJQComposes(t *testing.T) {
 			"--assert-body", "never-matches",
 			"--assert-status", "999",
 			url("/json"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "3 assertions failed:")
 		assertContains(t, r, "jq[")
 		assertContains(t, r, "body: expected to match")
@@ -146,7 +146,7 @@ func TestE2EAssertJQRejectsBadQueries(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			r := run(t, nil, "--assert-jq", tc.Query, url("/json"))
-			assertExit(t, r, exitBadFlagVal)
+			assertExit(t, r, exitBadInvocation)
 			assertContains(t, r, "Invalid value for --assert-jq flag")
 			assertContains(t, r, tc.Diag)
 		})
@@ -165,27 +165,27 @@ func TestE2EAssertJQRejectsBadQueries(t *testing.T) {
 func TestE2EAssertJQBodyProblems(t *testing.T) {
 	t.Run("a body that is not JSON", func(t *testing.T) {
 		r := run(t, nil, "--assert-jq", `. == 1`, url("/created"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "body: expected JSON")
 	})
 
 	t.Run("an empty body", func(t *testing.T) {
 		r := run(t, nil, "--assert-jq", `. == 1`, url("/empty"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "body: expected JSON")
 	})
 
 	// An encoding nothing can decode reports the encoding, not invalid JSON.
 	t.Run("a body still encoded", func(t *testing.T) {
 		r := run(t, nil, "--assert-jq", `. == 1`, url("/brotli"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "body: response is br-encoded")
 	})
 
 	// A query yielding nothing has checked nothing, so it must not pass.
 	t.Run("a query that matches nothing", func(t *testing.T) {
 		r := run(t, nil, "--assert-jq", `.users[] | select(.id == 99) | .active`, url("/json"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "expected true, got no output")
 	})
 
@@ -193,7 +193,7 @@ func TestE2EAssertJQBodyProblems(t *testing.T) {
 	// what the query actually produced so the reader can see why.
 	t.Run("a query that yields a value rather than a verdict", func(t *testing.T) {
 		r := run(t, nil, "--assert-jq", `.status`, url("/json"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, `expected true, got "success"`)
 	})
 }

--- a/e2e_known_issues_test.go
+++ b/e2e_known_issues_test.go
@@ -30,20 +30,10 @@ func TestKnownIssue23WildcardMaphostUnreachable(t *testing.T) {
 			characterizes(t, 23, "the parser rejects a wildcard the matcher supports")
 
 			r := run(t, nil, "--maphost", src+"="+hostPort(), "--assert-ok", "http://mapped.invalid/ok")
-			assertExit(t, r, exitBadFlagVal)
+			assertExit(t, r, exitBadInvocation)
 			assertContains(t, r, "Invalid value for --maphost flag")
 		})
 	}
-}
-
-// TestKnownIssue25NoAssertionsIsNotAUsageError: the condition is detected before
-// any request is made, yet reported with the transport-failure code.
-func TestKnownIssue25NoAssertionsIsNotAUsageError(t *testing.T) {
-	characterizes(t, 25, "a usage error is reported as 'Cannot perform request' with exit 93")
-
-	r := run(t, nil, url("/ok"))
-	assertExit(t, r, exitRequestFail) // ought to be exitUsage
-	assertContains(t, r, "Cannot perform request: no assertions defined")
 }
 
 // TestKnownIssue26MaphostErrorDiscarded: parseHostMappings produces a precise
@@ -52,7 +42,7 @@ func TestKnownIssue26MaphostErrorDiscarded(t *testing.T) {
 	characterizes(t, 26, "the specific parse error is replaced by the raw flag slice")
 
 	r := run(t, nil, "--maphost", "garbage", "--assert-ok", url("/ok"))
-	assertExit(t, r, exitBadFlagVal)
+	assertExit(t, r, exitBadInvocation)
 	assertContains(t, r, "Invalid value for --maphost flag: [garbage]")
 	assertNotContains(t, r, "has no separator")
 }

--- a/e2e_redirect_test.go
+++ b/e2e_redirect_test.go
@@ -22,7 +22,7 @@ func TestE2ERedirectDefaultIsNotToFollow(t *testing.T) {
 
 	t.Run("the destination is never fetched", func(t *testing.T) {
 		r := run(t, nil, "--assert-body-eq", "arrived", url("/hop?n=1"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 	})
 }
 
@@ -82,7 +82,7 @@ func TestE2ERedirectHopLimit(t *testing.T) {
 
 	t.Run("N+1 hops is refused", func(t *testing.T) {
 		r := run(t, nil, "-L", "--max-redirs", "2", "--assert-ok", url("/hop?n=3"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitTransportFail)
 		// Reported as this program stopping the chain, not as the network
 		// failing -- the reader would otherwise go looking for a broken host.
 		assertContains(t, r, "redirect chain was not followed to the end")
@@ -94,7 +94,7 @@ func TestE2ERedirectHopLimit(t *testing.T) {
 	// the >= net/http uses: zero has to refuse the first hop, not permit it.
 	t.Run("zero refuses every redirect", func(t *testing.T) {
 		r := run(t, nil, "-L", "--max-redirs", "0", "--assert-ok", url("/hop?n=1"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitTransportFail)
 		assertContains(t, r, "redirect chain was not followed to the end")
 	})
 
@@ -102,14 +102,14 @@ func TestE2ERedirectHopLimit(t *testing.T) {
 		assertExit(t, run(t, nil, "-L", "--assert-body-eq", "arrived", url("/hop?n=10")), exitOK)
 
 		r := run(t, nil, "-L", "--assert-ok", url("/hop?n=11"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitTransportFail)
 		assertContains(t, r, "--max-redirs is 10")
 	})
 
 	// Nothing else terminates this one.
 	t.Run("a redirect loop ends at the limit", func(t *testing.T) {
 		r := run(t, nil, "-L", "--assert-ok", url("/redirect-loop"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitTransportFail)
 		assertContains(t, r, "redirect chain was not followed to the end")
 	})
 }
@@ -146,7 +146,7 @@ func TestE2ERedirectRejectedCombinations(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			r := run(t, nil, tc.Args...)
-			assertExit(t, r, exitBadFlagVal)
+			assertExit(t, r, exitBadInvocation)
 			assertContains(t, r, tc.Diag)
 		})
 	}
@@ -163,7 +163,7 @@ func TestE2ERedirectRejectedCombinations(t *testing.T) {
 // else. Without the extra line the two read as a single exchange.
 func TestE2ERedirectFailureDumpNamesTheDestination(t *testing.T) {
 	r := run(t, nil, "-L", "--assert-status", "999", url("/redirect-local"))
-	assertExit(t, r, exitRequestFail)
+	assertExit(t, r, exitAssertFail)
 
 	assertContains(t, r, "FAILED: GET "+url("/redirect-local"))
 	assertContains(t, r, "Followed to: GET "+url("/ok"))

--- a/e2e_repeat_test.go
+++ b/e2e_repeat_test.go
@@ -51,14 +51,14 @@ func TestE2ERepeatedAssertionFlags(t *testing.T) {
 			if accumulates(f.Type) {
 				// Repeating these is the documented way to make several
 				// assertions, so it must not be an error.
-				if r.ExitCode == exitBadFlagVal {
+				if r.ExitCode == exitBadInvocation {
 					t.Fatalf("--%s (%s) rejected a repeat, but repeating it is how you add assertions\n%s",
 						f.Name, f.Type, r.Output())
 				}
 				return
 			}
 
-			assertExit(t, r, exitBadFlagVal)
+			assertExit(t, r, exitBadInvocation)
 			assertContains(t, r, "--"+f.Name+" was given 2 times")
 		})
 	}
@@ -75,6 +75,6 @@ func TestE2ERepeatedAssertionFlags(t *testing.T) {
 func TestE2ERepeatedAssertionKeepsNothingSilently(t *testing.T) {
 	r := run(t, nil, "--assert-status", "500", "--assert-status", "200", url("/ok"))
 
-	assertExit(t, r, exitBadFlagVal)
+	assertExit(t, r, exitBadInvocation)
 	assertNotContains(t, r, "PASSED")
 }

--- a/e2e_retry_test.go
+++ b/e2e_retry_test.go
@@ -34,7 +34,7 @@ func TestE2ERetryDefaultIsASingleAttempt(t *testing.T) {
 	// One failure is all it takes, and the endpoint would have recovered on the
 	// very next request. Without --retry there is no next request.
 	r := run(t, nil, "--assert-ok", flaky(t, "/flaky", 1))
-	assertExit(t, r, exitRequestFail)
+	assertExit(t, r, exitAssertFail)
 	if n := retries(r); n != 0 {
 		t.Fatalf("retried %d times with --retry unset\n%s", n, r.Output())
 	}
@@ -101,7 +101,7 @@ func TestE2ERetryRecovers(t *testing.T) {
 // reads as a service that was never up, rather than one that never came up.
 func TestE2ERetryExhaustion(t *testing.T) {
 	r := run(t, nil, "--retry", "2", "--retry-delay", "50ms", "--assert-ok", url("/500"))
-	assertExit(t, r, exitRequestFail)
+	assertExit(t, r, exitAssertFail)
 
 	// Two retries is three attempts, not two.
 	assertContains(t, r, "gave up after 3 attempts")
@@ -114,7 +114,7 @@ func TestE2ERetryExhaustion(t *testing.T) {
 
 	t.Run("--retry 0 is the default spelled out", func(t *testing.T) {
 		r := run(t, nil, "--retry", "0", "--assert-ok", url("/500"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertNotContains(t, r, "gave up after")
 		if n := retries(r); n != 0 {
 			t.Fatalf("retried %d times with --retry 0\n%s", n, r.Output())
@@ -129,7 +129,7 @@ func TestE2ERetryMaxTime(t *testing.T) {
 		start := time.Now()
 		r := run(t, nil, "--retry", "1000", "--retry-delay", "100ms",
 			"--retry-max-time", "1s", "--assert-ok", url("/500"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 
 		// Which bound stopped it is the whole reason the message names one.
 		assertContains(t, r, "--retry-max-time is 1s")
@@ -149,7 +149,7 @@ func TestE2ERetryMaxTime(t *testing.T) {
 	t.Run("zero means no budget", func(t *testing.T) {
 		r := run(t, nil, "--retry", "2", "--retry-delay", "50ms",
 			"--retry-max-time", "0", "--assert-ok", url("/500"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "gave up after 3 attempts")
 		assertNotContains(t, r, "--retry-max-time is")
 	})
@@ -158,7 +158,7 @@ func TestE2ERetryMaxTime(t *testing.T) {
 	t.Run("a budget larger than the count is not reported", func(t *testing.T) {
 		r := run(t, nil, "--retry", "1", "--retry-delay", "50ms",
 			"--retry-max-time", "1m", "--assert-ok", url("/500"))
-		assertExit(t, r, exitRequestFail)
+		assertExit(t, r, exitAssertFail)
 		assertContains(t, r, "gave up after 2 attempts")
 		assertNotContains(t, r, "--retry-max-time is")
 	})
@@ -172,7 +172,7 @@ func TestE2ERetryMaxTimeIsPerAttempt(t *testing.T) {
 	// on its own clock for the second one to happen at all.
 	r := run(t, nil, "-m", "1", "--retry", "1", "--retry-delay", "50ms",
 		"--assert-ok", url("/slow"))
-	assertExit(t, r, exitRequestFail)
+	assertExit(t, r, exitTransportFail)
 
 	if n := retries(r); n != 1 {
 		t.Fatalf("retried %d times, want 1 -- -m was read as a bound on the run\n%s",
@@ -221,7 +221,7 @@ func TestE2ERetryRejectedCombinations(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			r := run(t, nil, tc.Args...)
-			assertExit(t, r, exitBadFlagVal)
+			assertExit(t, r, exitBadInvocation)
 			assertContains(t, r, tc.Diag)
 		})
 	}
@@ -238,7 +238,7 @@ func TestE2ERetryRejectedCombinations(t *testing.T) {
 	// rejected by the flag parser rather than guessed at.
 	t.Run("a delay without a unit is refused", func(t *testing.T) {
 		r := run(t, nil, "--retry", "1", "--retry-delay", "5", "--assert-ok", url("/ok"))
-		assertExit(t, r, exitUsage)
+		assertExit(t, r, exitBadInvocation)
 		assertContains(t, r, `missing unit in duration "5"`)
 	})
 }

--- a/main.go
+++ b/main.go
@@ -30,10 +30,9 @@
 // broken invocation.
 //
 //	0    every assertion passed
-//	71   a flag or environment value was rejected
-//	91   the request could not be constructed from the method and URL
-//	93   the request failed, or at least one assertion did
-//	103  wrong argument count, or an unknown flag
+//	71   the invocation was rejected; no request was attempted
+//	92   the request produced no usable response
+//	93   a response arrived, and at least one assertion failed
 //
 // # Environment
 //
@@ -145,10 +144,9 @@ A query is compiled before the request is made, so a broken one exits 71.
 
 Exit codes:
   0    every assertion passed
-  71   a flag or environment value was rejected
-  91   the request could not be constructed from the method and URL
-  93   the request failed, or at least one assertion did
-  103  wrong argument count, or an unknown flag
+  71   the invocation was rejected; no request was attempted
+  92   the request produced no usable response
+  93   a response arrived, and at least one assertion failed
 
 Environment:
   Six options can also be set as HTTP_ASSERT_<NAME>, with dashes replaced by
@@ -212,6 +210,12 @@ Compression:
   http-assert -L --assert-status 200 https://example.com/old`,
 		Version: versionString(),
 		Args:    cobra.ExactArgs(1),
+		// Errors exit through dief with one line and the invocation code;
+		// cobra's own reporting would add a 40-line usage dump that buries
+		// the error and print it twice. --help is unaffected: cobra renders
+		// help before the silenced error path is reached.
+		SilenceErrors: true,
+		SilenceUsage:  true,
 		Run: func(cmd *cobra.Command, args []string) {
 			insecure, _ := cmd.Flags().GetBool("insecure")
 			maxTime, _ := cmd.Flags().GetInt("max-time")
@@ -248,9 +252,15 @@ Compression:
 				d, _ := cmd.Flags().GetString("data")
 				b = strings.NewReader(d)
 			}
+			assertions := parseAssertionFlags(cmd)
+			if len(assertions) == 0 {
+				dief(exitBadInvocation, "No assertions specified; pass at "+
+					"least one --assert-* flag (e.g. --assert-ok)")
+			}
+
 			req, err := http.NewRequestWithContext(cmd.Context(), m, args[0], b)
 			if err != nil {
-				dief(91, "Cannot create request '%s %s': %s", m, args[0], err)
+				dief(exitBadInvocation, "Cannot create request '%s %s': %s", m, args[0], err)
 			}
 
 			vs, _ := cmd.Flags().GetStringArray("header")
@@ -263,8 +273,18 @@ Compression:
 			if dataGiven && len(req.Header.Values("Content-Type")) == 0 {
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 			}
-			if err := c.Do(req, parseAssertionFlags(cmd)...); err != nil {
-				dief(93, "Cannot perform request: %s", err)
+			if err := c.Do(req, assertions...); err != nil {
+				// An error nobody tagged stays in the transport bucket: wrong
+				// by at most one category, and never reported as a usage
+				// mistake the caller did not make.
+				e := &exitError{code: exitTransportFail}
+				_ = errors.As(err, &e)
+				if e.code == exitAssertFail {
+					// The assertion dump names itself; a transport-flavoured
+					// prefix would send the reader to the network.
+					dief(exitAssertFail, "%s", err)
+				}
+				dief(e.code, "Cannot perform request: %s", err)
 			}
 		},
 	}
@@ -312,7 +332,10 @@ Compression:
 	}
 
 	if err := cmd.ExecuteContext(context.Background()); err != nil {
-		dief(103, "%s", err)
+		// Arg-count, unknown-flag and unparseable-value errors all land here,
+		// so a typo on the command line and the same typo in the environment
+		// finally exit with the same code.
+		dief(exitBadInvocation, "%s; run 'http-assert --help' for usage", err)
 	}
 }
 
@@ -350,7 +373,7 @@ func applyEnv(fs *pflag.FlagSet) {
 		}
 
 		if err := f.Value.Set(v); err != nil {
-			dief(71, "Invalid value for %s=%q: %s", key, v, err)
+			dief(exitBadInvocation, "Invalid value for %s=%q: %s", key, v, err)
 		}
 	}
 }
@@ -373,7 +396,7 @@ func checkRedirectFlags(fs *pflag.FlagSet) {
 	if follow {
 		for _, name := range []string{"assert-redirect", "assert-redirect-eq"} {
 			if fs.Changed(name) {
-				dief(71, "Flags --location and --%s cannot be used together: "+
+				dief(exitBadInvocation, "Flags --location and --%s cannot be used together: "+
 					"--location follows the redirect, which consumes the 3xx "+
 					"response --%s inspects", name, name)
 			}
@@ -384,11 +407,11 @@ func checkRedirectFlags(fs *pflag.FlagSet) {
 		return
 	}
 	if !follow {
-		dief(71, "Flag --max-redirs bounds a redirect chain that is not being "+
+		dief(exitBadInvocation, "Flag --max-redirs bounds a redirect chain that is not being "+
 			"followed; pass --location, or drop --max-redirs")
 	}
 	if n, _ := fs.GetInt("max-redirs"); n < 0 {
-		dief(71, "Invalid value for --max-redirs flag: %d; it counts redirects, "+
+		dief(exitBadInvocation, "Invalid value for --max-redirs flag: %d; it counts redirects, "+
 			"so the smallest meaningful value is 0", n)
 	}
 }
@@ -406,7 +429,7 @@ func checkRedirectFlags(fs *pflag.FlagSet) {
 // script, and refusing it would break a caller who did nothing wrong.
 func checkRetryFlags(fs *pflag.FlagSet) {
 	if n, _ := fs.GetInt("retry"); n < 0 {
-		dief(71, "Invalid value for --retry flag: %d; it counts retries, so the "+
+		dief(exitBadInvocation, "Invalid value for --retry flag: %d; it counts retries, so the "+
 			"smallest meaningful value is 0", n)
 	}
 
@@ -415,15 +438,40 @@ func checkRetryFlags(fs *pflag.FlagSet) {
 			continue
 		}
 		if !fs.Changed("retry") {
-			dief(71, "Flag --%s configures retrying that is not switched on; "+
+			dief(exitBadInvocation, "Flag --%s configures retrying that is not switched on; "+
 				"pass --retry, or drop --%s", name, name)
 		}
 		if d, _ := fs.GetDuration(name); d < 0 {
-			dief(71, "Invalid value for --%s flag: %s; it is a length of time, "+
+			dief(exitBadInvocation, "Invalid value for --%s flag: %s; it is a length of time, "+
 				"so the smallest meaningful value is 0", name, d)
 		}
 	}
 }
+
+// Exit codes. The code answers whose fault the failure is: the invocation
+// (fix the command line), the transport (no usable response arrived), or the
+// response (it arrived and said the wrong thing).
+//
+// The e2e harness keeps its own copy of these values because it tests the
+// built binary from the outside; the help test keeps both in step with the
+// documentation.
+const (
+	exitOK            = 0
+	exitBadInvocation = 71 // the request was never attempted; fix the command line
+	exitTransportFail = 92 // the request produced no usable response
+	exitAssertFail    = 93 // a response arrived and at least one assertion failed
+)
+
+// exitError carries the exit category from the place a failure is understood
+// -- inside the attempt, where transport and assertion failures are told
+// apart -- to the place the process exits. It survives the retry wrapper
+// because giveUp wraps with %w and errors.As unwraps it.
+type exitError struct {
+	code int
+	msg  string
+}
+
+func (e *exitError) Error() string { return e.msg }
 
 // dief formats a message to stderr and terminates the process with rc.
 func dief(rc int, format string, args ...interface{}) {
@@ -459,7 +507,7 @@ func mustParseLogLevel(cmd *cobra.Command) LogLevel {
 
 	res, ok := parseLogLevel(levelStr)
 	if !ok {
-		dief(71, "Invalid value for --log-level flag: %q", levelStr)
+		dief(exitBadInvocation, "Invalid value for --log-level flag: %q", levelStr)
 	}
 
 	return res
@@ -494,13 +542,13 @@ func parseLogLevel(s string) (LogLevel, bool) {
 // parser is right for one caller and wrong for the other.
 func mustParseRequestHeader(v string) (name, value string) {
 	if !strings.Contains(v, ":") {
-		dief(71, "Invalid value for --header flag: %q has no ':' separator; "+
+		dief(exitBadInvocation, "Invalid value for --header flag: %q has no ':' separator; "+
 			"write %q to send the header with an empty value", v, v+":")
 	}
 
 	name, value = parseHeaderLine(v)
 	if name == "" {
-		dief(71, "Invalid value for --header flag: %q has no header name "+
+		dief(exitBadInvocation, "Invalid value for --header flag: %q has no header name "+
 			"before the ':'", v)
 	}
 
@@ -510,7 +558,7 @@ func mustParseRequestHeader(v string) (name, value string) {
 func mustParseHostMappings(vals []string) []hostMapping {
 	res, err := parseHostMappings(vals)
 	if err != nil {
-		dief(71, "Invalid value for --maphost flag: %s", vals)
+		dief(exitBadInvocation, "Invalid value for --maphost flag: %s", vals)
 	}
 
 	return res
@@ -608,7 +656,7 @@ func rejectRepeats(fs *pflag.FlagSet) {
 func checkRepeats(fs *pflag.FlagSet) {
 	fs.VisitAll(func(f *pflag.Flag) {
 		if v, ok := f.Value.(*singleValue); ok && v.count > 1 {
-			dief(71, "Flag --%s was given %d times but accepts a single value; "+
+			dief(exitBadInvocation, "Flag --%s was given %d times but accepts a single value; "+
 				"repeat --assert-header, --assert-header-eq or --assert-header-missing "+
 				"to make several assertions", f.Name, v.count)
 		}
@@ -624,7 +672,7 @@ func checkRepeats(fs *pflag.FlagSet) {
 func mustCompileAssertion(flag, pattern string, build func(string) (Assertion, error)) Assertion {
 	a, err := build(pattern)
 	if err != nil {
-		dief(71, "Invalid value for %s flag: %s", flag, err)
+		dief(exitBadInvocation, "Invalid value for %s flag: %s", flag, err)
 	}
 
 	return a
@@ -786,8 +834,9 @@ var errTooManyRedirects = errors.New("too many redirects")
 func (c Client) Do(req *http.Request, assertions ...Assertion) error {
 	if len(assertions) == 0 {
 		// Not a failed attempt but a malformed invocation, so it is reported
-		// once rather than retried into the ground.
-		return fmt.Errorf("no assertions defined")
+		// once rather than retried into the ground. The CLI checks this before
+		// calling; the guard backstops any other caller.
+		return &exitError{exitBadInvocation, "no assertions defined"}
 	}
 
 	// Built once rather than per attempt: an http.Transport owns an idle
@@ -840,7 +889,7 @@ func (c Client) doOnce(client *http.Client, req *http.Request, assertions []Asse
 		var b strings.Builder
 		fmt.Fprintf(&b, "failed to rewind the request body:\n- %s\n", err)
 		c.writeHttpDetails(&b, req, nil)
-		return errors.New(b.String())
+		return &exitError{exitTransportFail, b.String()}
 	}
 	req = next
 
@@ -872,7 +921,7 @@ func (c Client) doOnce(client *http.Client, req *http.Request, assertions []Asse
 			c.logInfo("[-] FAILED %s: %s\n", time.Since(startedAt), err)
 		}
 		c.writeHttpDetails(&b, req, nil)
-		return errors.New(b.String())
+		return &exitError{exitTransportFail, b.String()}
 	}
 	defer func() { _ = res.Body.Close() }()
 
@@ -896,7 +945,7 @@ func (c Client) doOnce(client *http.Client, req *http.Request, assertions []Asse
 			fmt.Fprintf(&b, "- %s\n", assertErrors[i])
 		}
 		c.writeHttpDetails(&b, req, httpRes)
-		return errors.New(b.String())
+		return &exitError{exitAssertFail, b.String()}
 	}
 
 	c.logInfo("[+] PASSED %s\n\n", time.Since(startedAt))


### PR DESCRIPTION
## Problem

A CI job reading the exit code could not tell an unreachable service from one that answered wrongly, nor a forgotten flag from a network failure. The five codes had accidental boundaries — assigned by whichever internal layer failed, not by what kind of failure it was: the same typo exited `103` (with a 40-line usage dump) from the command line but `71` (one clean line) from the environment; a run with zero assertions reported the transport-failure code (#25); and the distinction the docs promise — "a broken service vs a broken invocation" — was exactly the one the codes didn't make.

## Solution

Three non-zero codes, each answering "whose fault?": `71` — the invocation was rejected, no request attempted; `92` — no usable response arrived; `93` — a response arrived and an assertion failed.

**Before → After:**

| Condition | Before | After |
|---|---|---|
| bad flag value / combination | 71 | 71 |
| bad value via environment | 71 | 71 |
| type typo, unknown flag, arg count | 103 + usage dump | 71, one line |
| unbuildable request (`-X`, URL) | 91 | 71 |
| zero assertions (#25) | 93 | 71 |
| unreachable / TLS / timeout / redirect bound | 93 | 92 |
| assertion failed | 93 | 93 |

Failure category is decided where it's understood — inside the attempt, where transport and assertion failures part ways — and carried to the exit in a typed error that survives the retry wrapper via `%w`/`errors.As`, so retry exhaustion inherits the last attempt's category. An untagged error defaults to the transport bucket: wrong by at most one category, never misreported as the caller's mistake. Cobra's own error printing is silenced so every failure exits through the same one-line path.

This is a **deliberate breaking change**, pre-1.0: `91`/`103` are gone and transport failures leave `93`. Scripts testing non-zero are unaffected; the README carries a migration note.

## Other Changes

- `TestE2EExitCodes` now covers all three categories plus both invocation channels — including the CLI-vs-environment typo pair that used to exit differently, and the zero-assertion case flipped out of the known-issues file per its protocol (closes #25).
- The help-sync test enumerates the new set and asserts the retired codes (2, 91, 103) are no longer advertised.
- Every exit-code assertion in the e2e suites was re-triaged individually (transport vs assertion), not batch-renamed.

Related:
- https://github.com/korya/http-assert/issues/25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiEcuZhTyL5XbrCwyiHau8
