### PR TITLE
Resolve verbosity conflicts by priority instead of silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,17 +392,9 @@ way. Reading those bytes as plain text would be its own silent corruption.
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--verbose` | `-v` | Enable verbose logging |
-| `--silent` | `-s` | Only log errors |
+| `--verbose` | `-v` | Enable verbose logging (overrides `--log-level`) |
+| `--silent` | `-s` | Only log errors (overrides `-v`) |
 | `--log-level` | | Set log level (debug, info, warn, error) |
-
-The three options set one level. When more than one asks, the command line
-beats the environment as a whole — so `-v` on a CI step overrides an
-`HTTP_ASSERT_SILENT` from the job template — and within one channel `-s`
-beats `-v` beats `--log-level`. A conflict never fails the run; each option
-that lost to a different level is announced with a one-line
-`Warning: -s overrides -v` on stderr, printed even when the winner is the
-silencing flag.
 
 **Everything the tool prints goes to stderr; stdout is always empty.** Use
 `2>&1` when capturing output in a file or a pipe.

--- a/README.md
+++ b/README.md
@@ -396,6 +396,14 @@ way. Reading those bytes as plain text would be its own silent corruption.
 | `--silent` | `-s` | Only log errors |
 | `--log-level` | | Set log level (debug, info, warn, error) |
 
+The three options set one level. When more than one asks, the command line
+beats the environment as a whole — so `-v` on a CI step overrides an
+`HTTP_ASSERT_SILENT` from the job template — and within one channel `-s`
+beats `-v` beats `--log-level`. A conflict never fails the run; each option
+that lost to a different level is announced with a one-line
+`Warning: -s overrides -v` on stderr, printed even when the winner is the
+silencing flag.
+
 **Everything the tool prints goes to stderr; stdout is always empty.** Use
 `2>&1` when capturing output in a file or a pipe.
 

--- a/e2e_assert_test.go
+++ b/e2e_assert_test.go
@@ -289,6 +289,89 @@ func TestE2ELogLevels(t *testing.T) {
 	})
 }
 
+// TestE2EVerbosityPriority pins how the three verbosity options resolve when
+// more than one asks for a level: the command line beats the environment as a
+// whole, within one channel -s beats -v beats --log-level, and every request
+// overridden to a different level is announced rather than silently dropped.
+//
+// Previously the ties resolved by an undocumented ladder with no announcement,
+// so -v -s ran verbose with no sign that -s lost (#29). A conflict is never an
+// error: the run proceeds at the winning level.
+func TestE2EVerbosityPriority(t *testing.T) {
+	okURL := url("/ok")
+
+	t.Run("-s beats -v, and says so despite winning silence", func(t *testing.T) {
+		r := run(t, nil, "-v", "-s", "--assert-ok", okURL)
+		assertExit(t, r, exitOK)
+		assertNotContains(t, r, "PASSED")
+		assertContains(t, r, "Warning: -s overrides -v")
+	})
+
+	t.Run("-s beats --log-level", func(t *testing.T) {
+		r := run(t, nil, "-s", "--log-level", "debug", "--assert-ok", okURL)
+		assertExit(t, r, exitOK)
+		assertNotContains(t, r, "PASSED")
+		assertContains(t, r, "Warning: -s overrides --log-level debug")
+	})
+
+	t.Run("-v beats --log-level", func(t *testing.T) {
+		r := run(t, nil, "-v", "--log-level", "error", "--assert-ok", okURL)
+		assertExit(t, r, exitOK)
+		assertContains(t, r, "PASSED")
+		assertContains(t, r, "Warning: -v overrides --log-level error")
+	})
+
+	t.Run("the command line beats the environment's silent", func(t *testing.T) {
+		r := run(t, map[string]string{"HTTP_ASSERT_SILENT": "true"}, "-v", "--assert-ok", okURL)
+		assertExit(t, r, exitOK)
+		assertContains(t, r, "PASSED")
+		assertContains(t, r, "Warning: -v overrides HTTP_ASSERT_SILENT")
+	})
+
+	// The case that used to invert the documented precedence: the
+	// environment's log level ate an explicit -v.
+	t.Run("the command line beats the environment's log level", func(t *testing.T) {
+		r := run(t, map[string]string{"HTTP_ASSERT_LOG_LEVEL": "error"}, "-v", "--assert-ok", okURL)
+		assertExit(t, r, exitOK)
+		assertContains(t, r, "PASSED")
+		assertContains(t, r, "Warning: -v overrides HTTP_ASSERT_LOG_LEVEL")
+	})
+
+	t.Run("within the environment, silent still beats verbose", func(t *testing.T) {
+		r := run(t, map[string]string{
+			"HTTP_ASSERT_VERBOSE": "true",
+			"HTTP_ASSERT_SILENT":  "true",
+		}, "--assert-ok", okURL)
+		assertExit(t, r, exitOK)
+		assertNotContains(t, r, "PASSED")
+		assertContains(t, r, "Warning: HTTP_ASSERT_SILENT overrides HTTP_ASSERT_VERBOSE")
+	})
+
+	// Nothing was overridden to a different level, so there is nothing to
+	// announce.
+	t.Run("an agreeing pair warns about nothing", func(t *testing.T) {
+		r := run(t, nil, "-v", "--log-level", "debug", "--assert-ok", okURL)
+		assertExit(t, r, exitOK)
+		assertContains(t, r, "PASSED")
+		assertNotContains(t, r, "Warning:")
+	})
+
+	// A false boolean declines to ask for a level rather than asking for the
+	// default: no conflict with -s, and it cancels the environment's verbose
+	// instead of losing to it.
+	t.Run("-v=false neither conflicts nor resurrects", func(t *testing.T) {
+		r := run(t, nil, "-v=false", "-s", "--assert-ok", okURL)
+		assertExit(t, r, exitOK)
+		assertNotContains(t, r, "PASSED")
+		assertNotContains(t, r, "Warning:")
+
+		r = run(t, map[string]string{"HTTP_ASSERT_VERBOSE": "true"}, "-v=false", "--assert-ok", okURL)
+		assertExit(t, r, exitOK)
+		assertContains(t, r, "PASSED") // info, not debug: the env verbose is gone
+		assertNotContains(t, r, "Warning:")
+	})
+}
+
 // TestE2EHeaderPresenceAssertions covers the bare-name form of both header
 // assertion flags, where the absence of a value means "assert present" rather
 // than "assert equal to the empty string".

--- a/main.go
+++ b/main.go
@@ -295,9 +295,9 @@ Compression:
 		"Provide a custom address for a specific host and port pair; "+
 			"e.g. <srchostname:srcport=dsthostname[:dstport]>")
 	cmd.PersistentFlags().BoolP("verbose", "v", false,
-		"Be verbose; log debug messages (same as --log-level debug)")
+		"Be verbose; log debug messages (same as --log-level debug; overrides --log-level)")
 	cmd.PersistentFlags().BoolP("silent", "s", false,
-		"Be silent; log error messages only (same as --log-level error)")
+		"Be silent; log error messages only (same as --log-level error; overrides -v)")
 	cmd.PersistentFlags().String("log-level", "",
 		"Set log level; possible values: debug, info (default), warn, error")
 	cmd.PersistentFlags().BoolP("insecure", "k", false, "Disable checking SSL certificates")

--- a/main.go
+++ b/main.go
@@ -491,26 +491,78 @@ const (
 	LDebug
 )
 
+// levelRequest is one verbosity option asking for a level, named the way the
+// caller spelled it so a conflict warning can point at the right surface.
+type levelRequest struct {
+	name  string
+	level LogLevel
+}
+
+// levelRequests returns the options that ask for a log level on one channel:
+// the command line when fromCLI, the environment otherwise. Changed tells the
+// channels apart -- parsing sets it, applyEnv's Value.Set does not. The slice
+// is in priority order, -s before -v before --log-level, so the first entry
+// is the channel's winner. A false boolean or an empty --log-level declines
+// to ask rather than asking for the default, which lets -v=false cancel an
+// environment-supplied verbose without starting a conflict.
+func levelRequests(fs *pflag.FlagSet, fromCLI bool) []levelRequest {
+	name := func(flag, env string) string {
+		if fromCLI {
+			return flag
+		}
+		return env
+	}
+
+	var res []levelRequest
+	if fs.Changed("silent") == fromCLI {
+		if v, _ := fs.GetBool("silent"); v {
+			res = append(res, levelRequest{name("-s", "HTTP_ASSERT_SILENT"), LError})
+		}
+	}
+	if fs.Changed("verbose") == fromCLI {
+		if v, _ := fs.GetBool("verbose"); v {
+			res = append(res, levelRequest{name("-v", "HTTP_ASSERT_VERBOSE"), LDebug})
+		}
+	}
+	if fs.Changed("log-level") == fromCLI {
+		if s, _ := fs.GetString("log-level"); s != "" {
+			lv, ok := parseLogLevel(s)
+			if !ok {
+				dief(exitBadInvocation, "Invalid value for --log-level flag: %q", s)
+			}
+			res = append(res, levelRequest{name("--log-level "+s, "HTTP_ASSERT_LOG_LEVEL"), lv})
+		}
+	}
+	return res
+}
+
+// mustParseLogLevel resolves the three verbosity options into one level: the
+// command line beats the environment as a whole, and within one channel -s
+// beats -v beats --log-level. A conflict never fails the run -- verbosity is
+// not worth aborting over -- but every overridden request that asked for a
+// different level is announced (#29).
+//
+// The announcement goes straight to stderr rather than through the logger:
+// a warn-severity log line would be suppressed by the very level it reports,
+// so `-v -s` would resolve to silent and swallow its own explanation.
 func mustParseLogLevel(cmd *cobra.Command) LogLevel {
-	levelStr, _ := cmd.Flags().GetString("log-level")
-	if levelStr == "" {
-		if v, _ := cmd.Flags().GetBool("verbose"); v {
-			return LDebug
-		}
-
-		if v, _ := cmd.Flags().GetBool("silent"); v {
-			return LError
-		}
-
+	fs := cmd.Flags()
+	// The command-line requests come first, so the head of the combined list
+	// is the overall winner and the environment's requests can only lead when
+	// no command-line option asked at all. Keeping the losing channel in the
+	// list is what makes a cross-channel override visible in the warning.
+	reqs := append(levelRequests(fs, true), levelRequests(fs, false)...)
+	if len(reqs) == 0 {
 		return LInfo
 	}
 
-	res, ok := parseLogLevel(levelStr)
-	if !ok {
-		dief(exitBadInvocation, "Invalid value for --log-level flag: %q", levelStr)
+	winner := reqs[0]
+	for _, loser := range reqs[1:] {
+		if loser.level != winner.level {
+			fmt.Fprintf(os.Stderr, "Warning: %s overrides %s\n", winner.name, loser.name)
+		}
 	}
-
-	return res
+	return winner.level
 }
 
 func parseLogLevel(s string) (LogLevel, bool) {


### PR DESCRIPTION
## Problem

Combining two verbosity options silently discarded one of them, with no rule saying which. `-v -s` ran verbose as if the `-s` was never typed, and — worse — an `HTTP_ASSERT_LOG_LEVEL` from a CI job template beat an explicit `-v` on the command line, inverting the documented "command line wins over the environment" rule exactly when someone was trying to debug a failing step.

## Solution

Resolve by explicit rule, never abort, and announce what happened: the command line beats the environment as a whole; within one channel `-s` beats `-v` beats `--log-level`; every request overridden to a different level prints one warning line.

**Before → After** (all exit 0, output on stderr):

| Invocation | Before | After |
|---|---|---|
| `-v -s` | runs verbose, `-s` vanishes | runs silent + `Warning: -s overrides -v` |
| `HTTP_ASSERT_LOG_LEVEL=error` + `-v` | env wins, `-v` vanishes | runs verbose + `Warning: -v overrides HTTP_ASSERT_LOG_LEVEL` |
| `HTTP_ASSERT_SILENT=true` + `-v` | verbose (by accident of ladder order) | verbose (by documented rule) + warning |
| `-v --log-level debug` | debug | debug, no warning — nothing was overridden that mattered |

Design choices worth a reviewer's attention:

- **Quiet wins within a channel** (`-s` on top): the conservative failure mode. Failures and the verdict still print at error level, so `-s` winning never hides why a run went red — while verbose winning would pollute the log someone explicitly asked to quiet.
- **The warning bypasses the log-level filter** (direct to stderr, like `Error:` lines): a warn-severity log entry would be suppressed by the very level it announces, making it invisible in the flagship `-v -s` case. `--log-level warn` therefore remains dead, and `TestKnownIssueWarnLevelIsDead` still passes untouched.
- **A false boolean declines to ask** rather than asking for the default, so `-v=false` cancels an environment-supplied verbose without starting a conflict or resurrecting anything.
- **No conflict → byte-identical behavior**, pinned by the existing log-level, config-matrix, and stdout-empty suites.

## Other Changes

- Nine-case `TestE2EVerbosityPriority` pins every pairing: three same-channel pairs, both cross-channel directions, the env-env pair, the agreeing pair, and both `-v=false` cancellations.
- The precedence lives as parentheticals on the flag descriptions themselves — README table and `--help` — rather than as a standalone paragraph.

Related:
- https://github.com/korya/http-assert/issues/29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiEcuZhTyL5XbrCwyiHau8
